### PR TITLE
Refactor admin panel and remove audit section

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,6 @@ const UserAdminPage = lazy(() => import('./page/UserAdminPage.jsx'));
 const SecretariaAdminPage = lazy(() => import('./page/SecretariaAdminPage.jsx'));
 const ChangePasswordPage = lazy(() => import('./page/ChangePasswordPage.jsx'));
 const ComparisonPage = lazy(() => import('./page/ComparisonPage.jsx'));
-const AuditPage = lazy(() => import('./page/AuditPage.jsx'));
 const SettingsPage = lazy(() => import('./page/SettingsPage.jsx'));
 const OrganigramaPage = lazy(() => import('./page/OrganigramaPage.jsx'));
 const UploadPage = lazy(() => import('./page/UploadPage.jsx'));
@@ -69,7 +68,6 @@ const AppLayout = () => {
               <Route path="/admin/users" element={<UserAdminPage />} />
               <Route path="/admin/secretarias" element={<SecretariaAdminPage />} />
               <Route path="/admin/upload" element={<UploadPage />} />
-              <Route path="/admin/audit" element={<AuditPage />} />
               <Route path="/admin/organigrama" element={<OrganigramaPage />} />
               <Route path="/admin/variables" element={<GestionVariablesPage />} />
               <Route path="/admin/plantillas" element={<GestionPlantillasPage />} />

--- a/frontend/src/components/AdminCard.jsx
+++ b/frontend/src/components/AdminCard.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { CardContent, Typography, Box, Avatar, Button } from '@mui/material';
+import { Link } from 'react-router-dom';
+import GlassCard from './GlassCard.jsx';
+
+const AdminCard = ({ title, description, icon: IconComponent, link, color, bgColor, isDarkMode }) => (
+  <GlassCard
+    isDarkMode={isDarkMode}
+    sx={{
+      height: 320,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      cursor: 'pointer',
+      '&:hover': {
+        transform: 'translateY(-8px)',
+        boxShadow: isDarkMode
+          ? `0 12px 40px rgba(0, 0, 0, 0.4), 0 4px 12px ${color}40`
+          : `0 12px 40px rgba(0, 0, 0, 0.15), 0 4px 12px ${color}30`,
+        background: bgColor,
+      },
+    }}
+    component={Link}
+    to={link}
+    style={{ textDecoration: 'none' }}
+  >
+    <CardContent
+      sx={{
+        textAlign: 'center',
+        p: 3,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        height: '100%',
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1 }}>
+        <Avatar
+          sx={{
+            width: 70,
+            height: 70,
+            mb: 2,
+            background: `linear-gradient(135deg, ${color}, ${color}dd)`,
+            boxShadow: `0 8px 25px ${color}40`,
+          }}
+        >
+          <IconComponent sx={{ fontSize: 35, color: 'white' }} />
+        </Avatar>
+
+        <Typography
+          variant="h6"
+          sx={{
+            fontWeight: 600,
+            mb: 1.5,
+            color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+            fontSize: '1.1rem',
+            textAlign: 'center',
+            lineHeight: 1.3,
+          }}
+        >
+          {title}
+        </Typography>
+
+        <Typography
+          variant="body2"
+          sx={{
+            color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
+            lineHeight: 1.5,
+            textAlign: 'center',
+            fontSize: '0.9rem',
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          {description}
+        </Typography>
+      </Box>
+
+      <Button
+        variant="contained"
+        sx={{
+          background: `linear-gradient(45deg, ${color}, ${color}dd)`,
+          color: 'white',
+          fontWeight: 600,
+          px: 3,
+          py: 1,
+          borderRadius: 2,
+          boxShadow: `0 4px 15px ${color}40`,
+          mt: 2,
+          '&:hover': {
+            background: `linear-gradient(45deg, ${color}dd, ${color}bb)`,
+            transform: 'translateY(-2px)',
+            boxShadow: `0 6px 20px ${color}50`,
+          },
+          transition: 'all 0.3s ease',
+        }}
+      >
+        Acceder
+      </Button>
+    </CardContent>
+  </GlassCard>
+);
+
+export default AdminCard;

--- a/frontend/src/components/AdminSectionLayout.jsx
+++ b/frontend/src/components/AdminSectionLayout.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Box, Typography, Avatar } from '@mui/material';
+import { useTheme } from '../context/ThemeContext.jsx';
+
+const AdminSectionLayout = ({ title, description, icon: Icon, color, maxWidth = 900, children }) => {
+  const { isDarkMode } = useTheme();
+
+  return (
+    <Box
+      sx={{
+        maxWidth,
+        mx: 'auto',
+        p: 4,
+        background: isDarkMode
+          ? 'linear-gradient(135deg, rgba(45, 55, 72, 0.3) 0%, rgba(26, 32, 44, 0.3) 100%)'
+          : 'linear-gradient(135deg, rgba(240, 249, 240, 0.3) 0%, rgba(227, 242, 253, 0.3) 100%)',
+        borderRadius: 3,
+        minHeight: '80vh',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4 }}>
+        <Avatar
+          sx={{
+            width: 48,
+            height: 48,
+            background: `linear-gradient(135deg, ${color}, ${color}dd)`,
+          }}
+        >
+          {Icon && <Icon sx={{ fontSize: 24 }} />}
+        </Avatar>
+        <Typography
+          variant="h3"
+          sx={{
+            fontWeight: 700,
+            color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+          }}
+        >
+          {title}
+        </Typography>
+      </Box>
+
+      {description && (
+        <Typography
+          variant="h6"
+          align="center"
+          sx={{
+            mb: 4,
+            color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
+            fontWeight: 400,
+          }}
+        >
+          {description}
+        </Typography>
+      )}
+
+      {children}
+    </Box>
+  );
+};
+
+export default AdminSectionLayout;

--- a/frontend/src/components/TourGuide.jsx
+++ b/frontend/src/components/TourGuide.jsx
@@ -81,12 +81,6 @@ const TourGuide = ({ isActive, onComplete, tourType = 'dashboard' }) => {
       placement: 'bottom',
     },
     {
-      target: '[data-tour="audit-logs"]',
-      content: 'Revisa el historial completo de actividades, descargas y cambios realizados en el sistema.',
-      title: 'Registros de Auditoría',
-      placement: 'bottom',
-    },
-    {
       target: '[data-tour="system-settings"]',
       content: 'Configura integraciones con servicios externos, notificaciones automáticas y políticas de retención de datos.',
       title: 'Configuración del Sistema',

--- a/frontend/src/page/AdminPage.jsx
+++ b/frontend/src/page/AdminPage.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Box, Typography, Grid, Card, CardContent, Button, Avatar } from '@mui/material';
+import { Box, Typography, Grid } from '@mui/material';
 import PeopleIcon from '@mui/icons-material/People';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import TuneIcon from '@mui/icons-material/Tune';
 import DescriptionIcon from '@mui/icons-material/Description';
-import HistoryEduIcon from '@mui/icons-material/HistoryEdu';
 import { useTheme } from '../context/ThemeContext.jsx';
+import AdminCard from '../components/AdminCard.jsx';
 
 const AdminPage = () => {
     const { isDarkMode } = useTheme();
@@ -30,7 +29,7 @@ const AdminPage = () => {
             bgColor: isDarkMode ? 'rgba(255, 152, 0, 0.1)' : 'rgba(255, 152, 0, 0.05)',
         },
         {
-            title: 'Gestión de Secretarías',
+            title: 'Gestión de Secretarias',
             description: 'Administra las dependencias jerárquicas del organigrama.',
             icon: AccountTreeIcon,
             link: '/admin/secretarias',
@@ -52,14 +51,6 @@ const AdminPage = () => {
             link: '/admin/plantillas',
             color: '#00bcd4', // Cyan
             bgColor: isDarkMode ? 'rgba(0, 188, 212, 0.1)' : 'rgba(0, 188, 212, 0.05)',
-        },
-        {
-            title: 'Auditoría',
-            description: 'Consulta el historial de acciones y registros de auditoría.',
-            icon: HistoryEduIcon,
-            link: '/admin/auditoria',
-            color: '#ff1744', // Rojo intenso
-            bgColor: isDarkMode ? 'rgba(255, 23, 68, 0.1)' : 'rgba(255, 23, 68, 0.05)',
         },
     ];
 
@@ -97,121 +88,15 @@ const AdminPage = () => {
                     fontWeight: 400,
                 }}
             >
-                Accede rápidamente a la gestión de usuarios, carga de archivos y dependencias desde un solo lugar.
+                Accede rápidamente a la gestión de usuarios, archivos, secretarias, variables y plantillas desde un solo lugar.
             </Typography>
             
             <Grid container spacing={4} justifyContent="center">
-                {adminCards.map((card, index) => {
-                    const IconComponent = card.icon;
-                    return (
-                        <Grid item xs={12} sm={6} md={4} lg={4} key={index}>
-                            <Card 
-                                sx={{ 
-                                    height: 320,
-                                    display: 'flex',
-                                    flexDirection: 'column',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    background: isDarkMode
-                                        ? 'rgba(45, 55, 72, 0.8)'
-                                        : 'rgba(255, 255, 255, 0.9)',
-                                    backdropFilter: 'blur(20px)',
-                                    border: isDarkMode
-                                        ? '1px solid rgba(255, 255, 255, 0.1)'
-                                        : '1px solid rgba(0, 0, 0, 0.1)',
-                                    borderRadius: 3,
-                                    transition: 'all 0.3s ease',
-                                    cursor: 'pointer',
-                                    '&:hover': {
-                                        transform: 'translateY(-8px)',
-                                        boxShadow: isDarkMode
-                                            ? `0 12px 40px rgba(0, 0, 0, 0.4), 0 4px 12px ${card.color}40`
-                                            : `0 12px 40px rgba(0, 0, 0, 0.15), 0 4px 12px ${card.color}30`,
-                                        background: card.bgColor,
-                                    }
-                                }}
-                                component={Link}
-                                to={card.link}
-                                style={{ textDecoration: 'none' }}
-                            >
-                                <CardContent sx={{ 
-                                    textAlign: 'center', 
-                                    p: 3,
-                                    display: 'flex',
-                                    flexDirection: 'column',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                    height: '100%',
-                                }}>
-                                    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1 }}>
-                                        <Avatar
-                                            sx={{
-                                                width: 70,
-                                                height: 70,
-                                                mb: 2,
-                                                background: `linear-gradient(135deg, ${card.color}, ${card.color}dd)`,
-                                                boxShadow: `0 8px 25px ${card.color}40`,
-                                            }}
-                                        >
-                                            <IconComponent sx={{ fontSize: 35, color: 'white' }} />
-                                        </Avatar>
-                                        
-                                        <Typography 
-                                            variant="h6" 
-                                            sx={{
-                                                fontWeight: 600,
-                                                mb: 1.5,
-                                                color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-                                                fontSize: '1.1rem',
-                                                textAlign: 'center',
-                                                lineHeight: 1.3,
-                                            }}
-                                        >
-                                            {card.title}
-                                        </Typography>
-                                        
-                                        <Typography 
-                                            variant="body2" 
-                                            sx={{
-                                                color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
-                                                lineHeight: 1.5,
-                                                textAlign: 'center',
-                                                fontSize: '0.9rem',
-                                                flex: 1,
-                                                display: 'flex',
-                                                alignItems: 'center',
-                                            }}
-                                        >
-                                            {card.description}
-                                        </Typography>
-                                    </Box>
-                                    
-                                    <Button 
-                                        variant="contained"
-                                        sx={{
-                                            background: `linear-gradient(45deg, ${card.color}, ${card.color}dd)`,
-                                            color: 'white',
-                                            fontWeight: 600,
-                                            px: 3,
-                                            py: 1,
-                                            borderRadius: 2,
-                                            boxShadow: `0 4px 15px ${card.color}40`,
-                                            mt: 2,
-                                            '&:hover': {
-                                                background: `linear-gradient(45deg, ${card.color}dd, ${card.color}bb)`,
-                                                transform: 'translateY(-2px)',
-                                                boxShadow: `0 6px 20px ${card.color}50`,
-                                            },
-                                            transition: 'all 0.3s ease',
-                                        }}
-                                    >
-                                        Acceder
-                                    </Button>
-                                </CardContent>
-                            </Card>
-                        </Grid>
-                    );
-                })}
+                {adminCards.map((card, index) => (
+                    <Grid item xs={12} sm={6} md={4} lg={4} key={index}>
+                        <AdminCard {...card} isDarkMode={isDarkMode} />
+                    </Grid>
+                ))}
             </Grid>
         </Box>
     );

--- a/frontend/src/page/AuditPage.jsx
+++ b/frontend/src/page/AuditPage.jsx
@@ -1,3 +1,0 @@
-import React from "react";
-const AuditPage = () => <div>Audit Page (en construcción)</div>;
-export default AuditPage; 

--- a/frontend/src/page/GestionPlantillasPage.jsx
+++ b/frontend/src/page/GestionPlantillasPage.jsx
@@ -28,8 +28,10 @@ import {
   CircularProgress
 } from '@mui/material';
 import { Add as AddIcon, Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import DescriptionIcon from '@mui/icons-material/Description';
 import { useTheme } from '../context/ThemeContext.jsx';
 import templateService from '../services/templateService';
+import AdminSectionLayout from '../components/AdminSectionLayout.jsx';
 
 // --- Componente de Modal --- //
 const TemplateModal = ({ isOpen, onClose, onSave, template, isDarkMode }) => {
@@ -293,42 +295,15 @@ const GestionPlantillasPage = () => {
   }
 
   return (
-    <Box 
-      sx={{ 
-        maxWidth: 1200, 
-        mx: 'auto', 
-        p: 4,
-        background: isDarkMode
-          ? 'linear-gradient(135deg, rgba(45, 55, 72, 0.3) 0%, rgba(26, 32, 44, 0.3) 100%)'
-          : 'linear-gradient(135deg, rgba(240, 249, 240, 0.3) 0%, rgba(227, 242, 253, 0.3) 100%)',
-        borderRadius: 3,
-        minHeight: '80vh',
-      }}
+    <AdminSectionLayout
+      title="Gestión de Plantillas"
+      description="Administra las plantillas de importación de Excel"
+      icon={DescriptionIcon}
+      color="#00bcd4"
+      maxWidth={1200}
     >
-      {/* Header */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
-        <Box>
-          <Typography 
-            variant="h3" 
-            sx={{
-              fontWeight: 700,
-              mb: 1,
-              color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-            }}
-          >
-            Gestión de Plantillas
-          </Typography>
-          <Typography 
-            variant="h6" 
-            sx={{
-              color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
-              fontWeight: 400,
-            }}
-          >
-            Administra las plantillas de importación de Excel
-          </Typography>
-        </Box>
-        <Button 
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 4 }}>
+        <Button
           onClick={() => handleOpenModal()}
           variant="contained"
           startIcon={<AddIcon />}
@@ -475,14 +450,14 @@ const GestionPlantillasPage = () => {
       </Card>
 
       {/* Modal */}
-      <TemplateModal 
-        isOpen={isModalOpen} 
-        onClose={handleCloseModal} 
-        onSave={handleSaveTemplate} 
+      <TemplateModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        onSave={handleSaveTemplate}
         template={selectedTemplate}
         isDarkMode={isDarkMode}
       />
-    </Box>
+    </AdminSectionLayout>
   );
 };
 

--- a/frontend/src/page/GestionVariablesPage.jsx
+++ b/frontend/src/page/GestionVariablesPage.jsx
@@ -13,6 +13,7 @@ import TuneIcon from '@mui/icons-material/Tune';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { useTheme } from '../context/ThemeContext.jsx';
 import { OptimizedTextField, OptimizedSelect, OptimizedCheckbox, useOptimizedForm } from '../components/OptimizedFormField.jsx';
+import AdminSectionLayout from '../components/AdminSectionLayout.jsx';
 
 const unidadesComunes = [
   'personas', '%', 'm²', 'kg', 'años', 'meses', 'días', 'horas', 'unidades', 'litros', 'toneladas', 'USD', 'ARS', 'otros...'
@@ -468,41 +469,17 @@ const GestionVariablesPage = () => {
   }
 
   return (
-    <Box 
-      sx={{ 
-        maxWidth: 1400, 
-        mx: 'auto', 
-        p: 4,
-        background: isDarkMode
-          ? 'linear-gradient(135deg, rgba(45, 55, 72, 0.3) 0%, rgba(26, 32, 44, 0.3) 100%)'
-          : 'linear-gradient(135deg, rgba(240, 249, 240, 0.3) 0%, rgba(227, 242, 253, 0.3) 100%)',
-        borderRadius: 3,
-        minHeight: '80vh',
-      }}
+    <AdminSectionLayout
+      title="Gestión de Variables"
+      description="Define, edita y elimina variables de referencia y sus umbrales."
+      icon={TuneIcon}
+      color="#9c27b0"
+      maxWidth={1400}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4 }}>
-        <Avatar sx={{ 
-          width: 48, 
-          height: 48, 
-          background: 'linear-gradient(135deg, #9c27b0, #7b1fa2)',
-        }}>
-          <TuneIcon sx={{ fontSize: 24 }} />
-        </Avatar>
-        <Typography 
-          variant="h3" 
-          sx={{
-            fontWeight: 700,
-            color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-          }}
-        >
-          Gestión de Variables
-        </Typography>
-      </Box>
-
-      <Tabs 
-        value={tab} 
-        onChange={(_, v) => setTab(v)} 
-        sx={{ 
+      <Tabs
+        value={tab}
+        onChange={(_, v) => setTab(v)}
+        sx={{
           mb: 4,
           '& .MuiTabs-indicator': {
             backgroundColor: '#9c27b0',
@@ -925,7 +902,7 @@ const GestionVariablesPage = () => {
           {snackbar.message}
         </Alert>
       </Snackbar>
-    </Box>
+    </AdminSectionLayout>
   );
 };
 

--- a/frontend/src/page/SecretariaAdminPage.jsx
+++ b/frontend/src/page/SecretariaAdminPage.jsx
@@ -8,6 +8,7 @@ import BusinessIcon from '@mui/icons-material/Business';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import { useTheme } from '../context/ThemeContext.jsx';
 import { OptimizedTextField, OptimizedCheckbox, useOptimizedForm } from '../components/OptimizedFormField.jsx';
+import AdminSectionLayout from '../components/AdminSectionLayout.jsx';
 
 // Componente de fila memoizado para evitar re-renders
 const SecretariaRow = memo(({ 
@@ -326,38 +327,13 @@ const SecretariaAdminPage = () => {
   }
 
   return (
-    <Box 
-      sx={{ 
-        maxWidth: 1400, 
-        mx: 'auto', 
-        p: 4,
-        background: isDarkMode
-          ? 'linear-gradient(135deg, rgba(45, 55, 72, 0.3) 0%, rgba(26, 32, 44, 0.3) 100%)'
-          : 'linear-gradient(135deg, rgba(240, 249, 240, 0.3) 0%, rgba(227, 242, 253, 0.3) 100%)',
-        borderRadius: 3,
-        minHeight: '80vh',
-      }}
+    <AdminSectionLayout
+      title="Gestión de Secretarias"
+      description="Administra las dependencias jerárquicas del organigrama."
+      icon={AccountTreeIcon}
+      color="#4caf50"
+      maxWidth={1400}
     >
-      {/* Header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4 }}>
-        <Avatar sx={{ 
-          width: 48, 
-          height: 48, 
-          background: 'linear-gradient(135deg, #4caf50, #388e3c)',
-        }}>
-          <AccountTreeIcon sx={{ fontSize: 24 }} />
-        </Avatar>
-        <Typography 
-          variant="h3" 
-          sx={{
-            fontWeight: 700,
-            color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-          }}
-        >
-          Gestión de Secretarías
-        </Typography>
-      </Box>
-
       {error && <Alert severity="error" sx={{ mb: 3 }}>{error}</Alert>}
 
       {/* Formulario de creación optimizado */}
@@ -660,7 +636,7 @@ const SecretariaAdminPage = () => {
           {snackbar.message}
         </Alert>
       </Snackbar>
-    </Box>
+    </AdminSectionLayout>
   );
 };
 

--- a/frontend/src/page/UploadPage.jsx
+++ b/frontend/src/page/UploadPage.jsx
@@ -1,59 +1,17 @@
 import React from 'react';
-import { Box, Typography, Avatar } from '@mui/material';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
-import { useTheme } from '../context/ThemeContext.jsx';
+import AdminSectionLayout from '../components/AdminSectionLayout.jsx';
 import UploadSection from '../components/UploadSection.jsx';
 
-const UploadPage = () => {
-  const { isDarkMode } = useTheme();
-
-  return (
-    <Box 
-      sx={{ 
-        maxWidth: 900, 
-        mx: 'auto', 
-        p: 4,
-        background: isDarkMode
-          ? 'linear-gradient(135deg, rgba(45, 55, 72, 0.3) 0%, rgba(26, 32, 44, 0.3) 100%)'
-          : 'linear-gradient(135deg, rgba(240, 249, 240, 0.3) 0%, rgba(227, 242, 253, 0.3) 100%)',
-        borderRadius: 3,
-        minHeight: '80vh',
-      }}
-    >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4 }}>
-        <Avatar sx={{ 
-          width: 48, 
-          height: 48, 
-          background: 'linear-gradient(135deg, #ff9800, #f57c00)',
-        }}>
-          <CloudUploadIcon sx={{ fontSize: 24 }} />
-        </Avatar>
-        <Typography 
-          variant="h3" 
-          sx={{
-            fontWeight: 700,
-            color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-          }}
-        >
-          Carga de Archivos Excel
-        </Typography>
-      </Box>
-      
-      <Typography 
-        variant="h6" 
-        align="center" 
-        sx={{
-          mb: 4,
-          color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
-          fontWeight: 400,
-        }}
-      >
-        Sube archivos de dotación para actualizar los datos del sistema de manera rápida y eficiente.
-      </Typography>
-
-      <UploadSection />
-    </Box>
-  );
-};
+const UploadPage = () => (
+  <AdminSectionLayout
+    title="Carga de Archivos Excel"
+    description="Sube archivos de dotación para actualizar los datos del sistema de manera rápida y eficiente."
+    icon={CloudUploadIcon}
+    color="#ff9800"
+  >
+    <UploadSection />
+  </AdminSectionLayout>
+);
 
 export default UploadPage;

--- a/frontend/src/page/UserAdminPage.jsx
+++ b/frontend/src/page/UserAdminPage.jsx
@@ -9,6 +9,7 @@ import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import PeopleIcon from '@mui/icons-material/People';
 import { useTheme } from '../context/ThemeContext.jsx';
 import { OptimizedTextField, OptimizedSelect, useOptimizedForm } from '../components/OptimizedFormField.jsx';
+import AdminSectionLayout from '../components/AdminSectionLayout.jsx';
 
 // Componente de fila de usuario memoizado
 const UserRow = memo(({ 
@@ -358,38 +359,13 @@ const UserAdminPage = () => {
   }
 
   return (
-    <Box 
-      sx={{ 
-        maxWidth: 1200, 
-        mx: 'auto', 
-        p: 4,
-        background: isDarkMode
-          ? 'linear-gradient(135deg, rgba(45, 55, 72, 0.3) 0%, rgba(26, 32, 44, 0.3) 100%)'
-          : 'linear-gradient(135deg, rgba(240, 249, 240, 0.3) 0%, rgba(227, 242, 253, 0.3) 100%)',
-        borderRadius: 3,
-        minHeight: '80vh',
-      }}
+    <AdminSectionLayout
+      title="Gestión de Usuarios"
+      description="Crea, edita y elimina usuarios del sistema."
+      icon={PeopleIcon}
+      color="#2196f3"
+      maxWidth={1200}
     >
-      {/* Header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4 }}>
-        <Avatar sx={{ 
-          width: 48, 
-          height: 48, 
-          background: 'linear-gradient(135deg, #2196f3, #1976d2)',
-        }}>
-          <PeopleIcon sx={{ fontSize: 24 }} />
-        </Avatar>
-        <Typography 
-          variant="h3" 
-          sx={{
-            fontWeight: 700,
-            color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-          }}
-        >
-          Gestión de Usuarios
-        </Typography>
-      </Box>
-
       {error && <Alert severity="error" sx={{ mb: 3 }}>{error}</Alert>}
 
       {/* Formulario de creación optimizado */}
@@ -539,7 +515,7 @@ const UserAdminPage = () => {
           {snackbar.message}
         </Alert>
       </Snackbar>
-    </Box>
+    </AdminSectionLayout>
   );
 };
 


### PR DESCRIPTION
## Summary
- factorize admin cards into reusable component and layout
- modernize admin pages for users, files, secretarias, variables, and plantillas
- remove unused audit section and associated tour step

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mapbox-gl)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689a00045b9883278a557726b01c1b75