### PR TITLE
Fix tab container height for hover animation

### DIFF
--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -213,10 +213,15 @@ const DashboardPage = () => {
                 pb: 4, // Más padding bottom para las animaciones
                 pt: 1  // Padding top también
             }}>
-                <Tabs 
-                    value={tabValue} 
-                    onChange={handleTabChange} 
-                    sx={{ 
+                <Tabs
+                    value={tabValue}
+                    onChange={handleTabChange}
+                    sx={{
+                        minHeight: 56,
+                        '& .MuiTabs-scroller': {
+                            overflow: 'visible',
+                            minHeight: 56,
+                        },
                         '& .MuiTabs-indicator': {
                             display: 'none',
                         },


### PR DESCRIPTION
## Summary
- ensure Tabs scroller matches tab height to prevent hover animation clipping

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a050d7f648327be7d0dec795efbc5