### PR TITLE
Refactor login and enhance dashboard navigation

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -16,6 +16,7 @@ import Brightness7Icon from '@mui/icons-material/Brightness7';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import HomeIcon from '@mui/icons-material/Home';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import LogoutIcon from '@mui/icons-material/Logout';
 import PersonIcon from '@mui/icons-material/Person';
@@ -444,13 +445,13 @@ const Navbar = () => {
             </Button>
           )}
           
-          {/* Botón Dashboard */}
+          {/* Botón Dashboard General */}
           {user && (
-            <Button 
-              component={Link} 
+            <Button
+              component={Link}
               to="/dashboard"
               startIcon={<DashboardIcon />}
-              sx={{ 
+              sx={{
                 color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
                 fontWeight: 600,
                 px: 3,
@@ -458,15 +459,15 @@ const Navbar = () => {
                 borderRadius: 3,
                 textTransform: 'none',
                 fontSize: '0.9rem',
-                background: isDarkMode 
-                  ? 'rgba(255, 255, 255, 0.05)' 
+                background: isDarkMode
+                  ? 'rgba(255, 255, 255, 0.05)'
                   : 'rgba(255, 255, 255, 0.7)',
                 border: isDarkMode
                   ? '1px solid rgba(255, 255, 255, 0.1)'
                   : '1px solid rgba(0, 0, 0, 0.08)',
                 '&:hover': {
-                  background: isDarkMode 
-                    ? 'rgba(33, 150, 243, 0.2)' 
+                  background: isDarkMode
+                    ? 'rgba(33, 150, 243, 0.2)'
                     : 'rgba(33, 150, 243, 0.15)',
                   color: isDarkMode ? '#64b5f6' : '#1976d2',
                   transform: 'translateY(-2px)',
@@ -477,7 +478,44 @@ const Navbar = () => {
                 transition: 'all 0.3s ease',
               }}
             >
-              Dashboard
+              Dashboard General
+            </Button>
+          )}
+
+          {/* Botón Dashboard Específico */}
+          {user && (
+            <Button
+              component={Link}
+              to="/"
+              startIcon={<DashboardCustomizeIcon />}
+              sx={{
+                color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+                fontWeight: 600,
+                px: 3,
+                py: 1.5,
+                borderRadius: 3,
+                textTransform: 'none',
+                fontSize: '0.9rem',
+                background: isDarkMode
+                  ? 'rgba(255, 255, 255, 0.05)'
+                  : 'rgba(255, 255, 255, 0.7)',
+                border: isDarkMode
+                  ? '1px solid rgba(255, 255, 255, 0.1)'
+                  : '1px solid rgba(0, 0, 0, 0.08)',
+                '&:hover': {
+                  background: isDarkMode
+                    ? 'rgba(76, 175, 80, 0.2)'
+                    : 'rgba(76, 175, 80, 0.15)',
+                  color: isDarkMode ? '#81c784' : '#388e3c',
+                  transform: 'translateY(-2px)',
+                  boxShadow: isDarkMode
+                    ? '0 6px 20px rgba(76, 175, 80, 0.3)'
+                    : '0 6px 20px rgba(76, 175, 80, 0.2)',
+                },
+                transition: 'all 0.3s ease',
+              }}
+            >
+              Dashboard Específico
             </Button>
           )}
           

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -194,7 +194,7 @@ const DashboardPage = () => {
                     mb: 1,
                 }}
             >
-                Dashboard de Análisis Municipal
+                Dashboard General de Análisis Municipal
             </Typography>
             <Typography 
                 variant="h6" 

--- a/frontend/src/page/LoginPage.jsx
+++ b/frontend/src/page/LoginPage.jsx
@@ -1,7 +1,7 @@
 // ARCHIVO: src/pages/LoginPage.jsx - Rediseño Institucional Moderno
 
-import React, { useState, useContext } from 'react';
-import AuthContext from '../context/AuthContext.jsx';
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext.jsx';
 import { useNavigate } from 'react-router-dom';
 import { TextField, Button, Card, CardContent, Typography, CircularProgress, Alert, Box, IconButton, Tooltip, InputAdornment, Avatar } from '@mui/material';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
@@ -17,7 +17,7 @@ const LoginPage = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const { login } = useContext(AuthContext);
+  const { login } = useAuth();
   const navigate = useNavigate();
   const { isDarkMode, toggleTheme } = useTheme();
 


### PR DESCRIPTION
## Summary
- Refactor login page to leverage `useAuth` hook
- Rename dashboard link to "Dashboard General" and add "Dashboard Específico" placeholder
- Update dashboard heading accordingly

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689a0e0ee0408327b735316d89e090b4