### PR TITLE
Enable functional filters and improve search UI

### DIFF
--- a/backend/controllers/analyticsController.js
+++ b/backend/controllers/analyticsController.js
@@ -3,6 +3,20 @@ const Agent = require('../models/Agent'); // Importamos el modelo Agent
 const PDFDocument = require('pdfkit');
 const emailService = require('../services/emailService');
 
+// Construye dinámicamente el objeto de filtros para consultas
+const buildMatchStage = (query) => {
+  const match = { plantilla: "Rama completa - Planta" };
+  if (query.dependencia) match['Dependencia donde trabaja'] = query.dependencia;
+  if (query.secretaria) match['Secretaria'] = query.secretaria;
+  if (query.subsecretaria) match['Subsecretaria'] = query.subsecretaria;
+  if (query.direccionGeneral) match['Dirección general'] = query.direccionGeneral;
+  if (query.direccion) match['Dirección'] = query.direccion;
+  if (query.departamento) match['Departamento'] = query.departamento;
+  if (query.division) match['División'] = query.division;
+  if (query.funcion) match['Funcion'] = query.funcion;
+  return match;
+};
+
 // Obtener lista de secretarías disponibles
 const getSecretarias = async (req, res) => {
   try {
@@ -261,7 +275,8 @@ const getSecretariasAnalytics = async (req, res) => {
 // @access  Private/Admin
 const getTotalAgents = async (req, res) => {
   try {
-    const totalAgents = await Agent.countDocuments();
+    const match = buildMatchStage(req.query);
+    const totalAgents = await Agent.countDocuments(match);
     res.json({ total: totalAgents });
   } catch (err) {
     console.error(err.message);
@@ -276,8 +291,9 @@ const getTotalAgents = async (req, res) => {
 // @access  Private/Admin
 const getAgentsByFunction = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsByFunction = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$Funcion',
@@ -307,9 +323,10 @@ const getAgentsByFunction = async (req, res) => {
 // @access  Private/Admin
 const getAgeDistribution = async (req, res) => {
   try {
-    const agents = await Agent.find({ 
-      'Fecha de nacimiento': { $exists: true, $ne: null, $ne: '' },
-      plantilla: "Rama completa - Planta"
+    const match = buildMatchStage(req.query);
+    const agents = await Agent.find({
+      ...match,
+      'Fecha de nacimiento': { $exists: true, $ne: null, $ne: '' }
     }).limit(1000);
 
     const currentDate = new Date();
@@ -381,10 +398,11 @@ const getAgeDistribution = async (req, res) => {
 // @access  Private/Admin
 const getAgeByFunction = async (req, res) => {
   try {
-    const agents = await Agent.find({ 
+    const match = buildMatchStage(req.query);
+    const agents = await Agent.find({
+      ...match,
       'Fecha de nacimiento': { $exists: true, $ne: null, $ne: '' },
-      'Funcion': { $exists: true, $ne: null, $ne: '' },
-      plantilla: "Rama completa - Planta"
+      'Funcion': { $exists: true, $ne: null, $ne: '' }
     }).limit(2000);
 
     const currentDate = new Date();
@@ -446,10 +464,11 @@ const getAgeByFunction = async (req, res) => {
 // @access  Private/Admin
 const getAgeBySecretaria = async (req, res) => {
   try {
-    const agents = await Agent.find({ 
+    const match = buildMatchStage(req.query);
+    const agents = await Agent.find({
+      ...match,
       'Fecha de nacimiento': { $exists: true, $ne: null, $ne: '' },
-      'Secretaria': { $exists: true, $ne: null, $ne: '' },
-      plantilla: "Rama completa - Planta"
+      'Secretaria': { $exists: true, $ne: null, $ne: '' }
     }).limit(2000);
 
     const currentDate = new Date();
@@ -511,8 +530,9 @@ const getAgeBySecretaria = async (req, res) => {
 // @access  Private/Admin
 const getAgentsByEmploymentType = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsByType = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$Situación de revista',
@@ -542,8 +562,9 @@ const getAgentsByEmploymentType = async (req, res) => {
 // @access  Private/Admin
 const getAgentsByDependency = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsByDependency = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$Dependencia donde trabaja',
@@ -573,8 +594,9 @@ const getAgentsByDependency = async (req, res) => {
 // @access  Private/Admin
 const getAgentsBySecretaria = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsBySecretaria = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$Secretaria',
@@ -604,8 +626,9 @@ const getAgentsBySecretaria = async (req, res) => {
 // @access  Private/Admin
 const getAgentsBySubsecretaria = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsBySubsecretaria = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$Subsecretaria',
@@ -635,8 +658,9 @@ const getAgentsBySubsecretaria = async (req, res) => {
 // @access  Private/Admin
 const getAgentsByDireccionGeneral = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsByDireccionGeneral = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$Dirección general',
@@ -666,8 +690,9 @@ const getAgentsByDireccionGeneral = async (req, res) => {
 // @access  Private/Admin
 const getAgentsByDireccion = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsByDireccion = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$Dirección',
@@ -697,8 +722,9 @@ const getAgentsByDireccion = async (req, res) => {
 // @access  Private/Admin
 const getAgentsByDepartamento = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsByDepartamento = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$Departamento',
@@ -728,8 +754,9 @@ const getAgentsByDepartamento = async (req, res) => {
 // @access  Private/Admin
 const getAgentsByDivision = async (req, res) => {
   try {
+    const match = buildMatchStage(req.query);
     const agentsByDivision = await Agent.aggregate([
-      { $match: { plantilla: "Rama completa - Planta" } },
+      { $match: match },
       {
         $group: {
           _id: '$División',

--- a/frontend/src/components/DependencyFilter.jsx
+++ b/frontend/src/components/DependencyFilter.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Card, CardContent, Grid, TextField, Button } from '@mui/material';
+import { Card, CardContent, Grid, TextField, Button, Box } from '@mui/material';
 
 const defaultFilters = {
   dependencia: '',
@@ -30,13 +30,13 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
   };
 
   return (
-    <Card sx={{ mb: 3 }}>
+    <Card sx={{ mb: 3, p: 2, boxShadow: 3 }}>
       <CardContent>
         <Grid container spacing={2}>
           <Grid item xs={12} sm={6} md={3}>
             <TextField
               fullWidth
-              required
+              size="small"
               label="Dependencia"
               value={localFilters.dependencia}
               onChange={handleChange('dependencia')}
@@ -45,6 +45,7 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
           <Grid item xs={12} sm={6} md={3}>
             <TextField
               fullWidth
+              size="small"
               label="Secretaría"
               value={localFilters.secretaria}
               onChange={handleChange('secretaria')}
@@ -53,6 +54,7 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
           <Grid item xs={12} sm={6} md={3}>
             <TextField
               fullWidth
+              size="small"
               label="Subsecretaría"
               value={localFilters.subsecretaria}
               onChange={handleChange('subsecretaria')}
@@ -61,6 +63,7 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
           <Grid item xs={12} sm={6} md={3}>
             <TextField
               fullWidth
+              size="small"
               label="Dirección General"
               value={localFilters.direccionGeneral}
               onChange={handleChange('direccionGeneral')}
@@ -69,6 +72,7 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
           <Grid item xs={12} sm={6} md={3}>
             <TextField
               fullWidth
+              size="small"
               label="Dirección"
               value={localFilters.direccion}
               onChange={handleChange('direccion')}
@@ -77,6 +81,7 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
           <Grid item xs={12} sm={6} md={3}>
             <TextField
               fullWidth
+              size="small"
               label="Departamento"
               value={localFilters.departamento}
               onChange={handleChange('departamento')}
@@ -85,6 +90,7 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
           <Grid item xs={12} sm={6} md={3}>
             <TextField
               fullWidth
+              size="small"
               label="División"
               value={localFilters.division}
               onChange={handleChange('division')}
@@ -93,15 +99,18 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
           <Grid item xs={12} sm={6} md={3}>
             <TextField
               fullWidth
+              size="small"
               label="Función"
               value={localFilters.funcion}
               onChange={handleChange('funcion')}
             />
           </Grid>
           <Grid item xs={12}>
-            <Button variant="contained" color="primary" onClick={handleSubmit}>
-              Filtrar
-            </Button>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button variant="contained" color="primary" onClick={handleSubmit}>
+                Filtrar
+              </Button>
+            </Box>
           </Grid>
         </Grid>
       </CardContent>

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -77,70 +77,70 @@ const DashboardPage = () => {
         });
     };
 
+    const fetchAllData = async (appliedFilters = filters) => {
+        setLoading(true);
+        setError('');
+
+        try {
+            const funcRes = await apiClient.get('/functions');
+            const funcs = funcRes.data.reduce((acc, f) => { acc[f.name] = f.endpoint; return acc; }, {});
+
+            const [
+                totalResponse,
+                ageDistResponse,
+                ageFunctionResponse,
+                functionResponse,
+                employmentResponse,
+                dependencyResponse,
+                secretariaResponse,
+                subsecretariaResponse,
+                direccionGeneralResponse,
+                direccionResponse,
+                departamentoResponse,
+                divisionResponse
+            ] = await Promise.all([
+                apiClient.get(funcs.totalAgents, { params: appliedFilters }),
+                apiClient.get(funcs.ageDistribution, { params: appliedFilters }),
+                apiClient.get(funcs.ageByFunction, { params: appliedFilters }),
+                apiClient.get(funcs.agentsByFunction, { params: appliedFilters }),
+                apiClient.get(funcs.agentsByEmploymentType, { params: appliedFilters }),
+                apiClient.get(funcs.agentsByDependency, { params: appliedFilters }),
+                apiClient.get(funcs.agentsBySecretaria, { params: appliedFilters }),
+                apiClient.get(funcs.agentsBySubsecretaria, { params: appliedFilters }),
+                apiClient.get(funcs.agentsByDireccionGeneral, { params: appliedFilters }),
+                apiClient.get(funcs.agentsByDireccion, { params: appliedFilters }),
+                apiClient.get(funcs.agentsByDepartamento, { params: appliedFilters }),
+                apiClient.get(funcs.agentsByDivision, { params: appliedFilters })
+            ]);
+
+            setTotalAgents(totalResponse.data.total);
+            setAgeDistribution(ageDistResponse.data);
+            setAgeByFunction(ageFunctionResponse.data);
+            setAgentsByFunction(functionResponse.data);
+            setAgentsByEmploymentType(employmentResponse.data);
+            setAgentsByDependency(dependencyResponse.data);
+            setAgentsBySecretaria(secretariaResponse.data);
+            setAgentsBySubsecretaria(subsecretariaResponse.data);
+            setAgentsByDireccionGeneral(direccionGeneralResponse.data);
+            setAgentsByDireccion(direccionResponse.data);
+            setAgentsByDepartamento(departamentoResponse.data);
+            setAgentsByDivision(divisionResponse.data);
+
+        } catch (err) {
+            setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
+            console.error(err);
+        } finally {
+            setLoading(false);
+        }
+    };
+
     const handleApplyFilters = (newFilters) => {
         setFilters(newFilters);
-        // En una implementación real se llamarían a los endpoints con estos filtros
+        fetchAllData(newFilters);
     };
 
     useEffect(() => {
-        const fetchAllData = async () => {
-            setLoading(true);
-            setError('');
-
-            try {
-                const funcRes = await apiClient.get('/functions');
-                const funcs = funcRes.data.reduce((acc, f) => { acc[f.name] = f.endpoint; return acc; }, {});
-
-                const [
-                    totalResponse,
-                    ageDistResponse,
-                    ageFunctionResponse,
-                    functionResponse,
-                    employmentResponse,
-                    dependencyResponse,
-                    secretariaResponse,
-                    subsecretariaResponse,
-                    direccionGeneralResponse,
-                    direccionResponse,
-                    departamentoResponse,
-                    divisionResponse
-                ] = await Promise.all([
-                    apiClient.get(funcs.totalAgents),
-                    apiClient.get(funcs.ageDistribution),
-                    apiClient.get(funcs.ageByFunction),
-                    apiClient.get(funcs.agentsByFunction),
-                    apiClient.get(funcs.agentsByEmploymentType),
-                    apiClient.get(funcs.agentsByDependency),
-                    apiClient.get(funcs.agentsBySecretaria),
-                    apiClient.get(funcs.agentsBySubsecretaria),
-                    apiClient.get(funcs.agentsByDireccionGeneral),
-                    apiClient.get(funcs.agentsByDireccion),
-                    apiClient.get(funcs.agentsByDepartamento),
-                    apiClient.get(funcs.agentsByDivision)
-                ]);
-
-                setTotalAgents(totalResponse.data.total);
-                setAgeDistribution(ageDistResponse.data);
-                setAgeByFunction(ageFunctionResponse.data);
-                setAgentsByFunction(functionResponse.data);
-                setAgentsByEmploymentType(employmentResponse.data);
-                setAgentsByDependency(dependencyResponse.data);
-                setAgentsBySecretaria(secretariaResponse.data);
-                setAgentsBySubsecretaria(subsecretariaResponse.data);
-                setAgentsByDireccionGeneral(direccionGeneralResponse.data);
-                setAgentsByDireccion(direccionResponse.data);
-                setAgentsByDepartamento(departamentoResponse.data);
-                setAgentsByDivision(divisionResponse.data);
-
-            } catch (err) {
-                setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
-                console.error(err);
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchAllData();
+        fetchAllData(filters);
     }, []);
 
     const getTabButtonStyles = (value) => ({


### PR DESCRIPTION
## Summary
- Add reusable `buildMatchStage` to backend analytics and apply filters to all dashboard endpoints
- Allow optional dependency field and polish filter card styling
- Trigger API requests with selected filters so dashboard charts update dynamically

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b300476388327bc976f4a0817439e