### PR TITLE
Rename dashboard buttons for clarity

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -122,7 +122,7 @@ const Navbar = () => {
             </Button>
           )}
           
-          {/* Botón Dashboard General */}
+          {/* Botón Dashboard */}
           {user && (
             <Button
               component={Link}
@@ -155,11 +155,11 @@ const Navbar = () => {
                 transition: 'all 0.3s ease',
               }}
             >
-              Dashboard General
+              Dashboard
             </Button>
           )}
 
-          {/* Botón Dashboard Específico */}
+          {/* Botón Funciones */}
           {user && (
             <Button
               component={Link}
@@ -192,7 +192,7 @@ const Navbar = () => {
                 transition: 'all 0.3s ease',
               }}
             >
-              Dashboard Específico
+              Funciones
             </Button>
           )}
           

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -212,7 +212,7 @@ const DashboardPage = () => {
                     mb: 1,
                 }}
             >
-                Dashboard General de Análisis Municipal
+                Dashboard de Análisis Municipal
             </Typography>
             <Typography
                 variant="h6"


### PR DESCRIPTION
## Summary
- Rename "Dashboard General" button to "Dashboard"
- Rename "Dashboard Específico" button to "Funciones" redirecting to home
- Update dashboard page title to match new naming

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm run lint` *(fails: Cannot find package '/workspace/AnalisisDeDotacion/frontend/node_modules/@eslint/js/index.js')*


------
https://chatgpt.com/codex/tasks/task_e_689b2fc01e408327965a9db110b14308