### PR TITLE
feat: soportar plantillas en DashboardPage

### DIFF
--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -98,13 +98,19 @@ const DashboardPage = () => {
             const funcRes = await apiClient.get('/functions');
             const funcs = funcRes.data.reduce((acc, f) => { acc[f.name] = f.endpoint; return acc; }, {});
 
-            const safeGet = (endpoint, defaultData) => {
+            const safeGet = (endpoint, defaultData, plantilla) => {
                 if (!endpoint) return Promise.resolve({ data: defaultData });
+                const params = { ...appliedFilters };
+                if (plantilla) {
+                    params.plantilla = plantilla;
+                }
                 return apiClient
-                    .get(endpoint, { params: appliedFilters })
+                    .get(endpoint, { params })
                     .catch(() => ({ data: defaultData }));
             };
 
+            const TEMPLATE_PLANTA_CONTRATOS = 'Planta y Contratos';
+            const TEMPLATE_NEIKES_BECAS = 'Neikes y Becas';
             const [
                 totalResponse,
                 ageDistResponse,
@@ -130,29 +136,29 @@ const DashboardPage = () => {
                 departamentoNeikeBecaResponse,
                 divisionNeikeBecaResponse
             ] = await Promise.all([
-                safeGet(funcs.totalAgents, { total: 0 }),
-                safeGet(funcs.ageDistribution, null),
-                safeGet(funcs.ageByFunction, []),
-                safeGet(funcs.agentsByFunction, []),
-                safeGet(funcs.agentsByEmploymentType, []),
-                safeGet(funcs.agentsByDependency, []),
-                safeGet(funcs.agentsBySecretaria, []),
-                safeGet(funcs.agentsBySubsecretaria, []),
-                safeGet(funcs.agentsByDireccionGeneral, []),
-                safeGet(funcs.agentsByDireccion, []),
-                safeGet(funcs.agentsByDepartamento, []),
-                safeGet(funcs.agentsByDivision, []),
-                safeGet(funcs.agentsByFunctionNeikeBeca, []),
-                safeGet(funcs.agentsByEmploymentTypeNeikeBeca, []),
-                safeGet(funcs.ageDistributionNeikeBeca, null),
-                safeGet(funcs.ageByFunctionNeikeBeca, []),
-                safeGet(funcs.agentsByDependencyNeikeBeca, []),
-                safeGet(funcs.agentsBySecretariaNeikeBeca, []),
-                safeGet(funcs.agentsBySubsecretariaNeikeBeca, []),
-                safeGet(funcs.agentsByDireccionGeneralNeikeBeca, []),
-                safeGet(funcs.agentsByDireccionNeikeBeca, []),
-                safeGet(funcs.agentsByDepartamentoNeikeBeca, []),
-                safeGet(funcs.agentsByDivisionNeikeBeca, [])
+                safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.ageDistribution, null, TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.ageByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByEmploymentType, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDependency, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsBySecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsBySubsecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDireccionGeneral, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDireccion, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDepartamento, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDivision, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByFunctionNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByEmploymentTypeNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.ageDistributionNeikeBeca, null, TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.ageByFunctionNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDependencyNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsBySecretariaNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsBySubsecretariaNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDireccionGeneralNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDireccionNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDepartamentoNeikeBeca, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDivisionNeikeBeca, [], TEMPLATE_NEIKES_BECAS)
             ]);
 
             setTotalAgents(totalResponse.data.total);


### PR DESCRIPTION
### **User description**
## Summary
- aceptar parámetro de plantilla en las solicitudes del dashboard
- enviar nombres de plantilla correspondientes a Planta y Contratos y a Neikes y Becas

## Testing
- `npm test` *(falla: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4d8419ca083279e6eb6ef49a5e8dc


___

### **PR Type**
Enhancement


___

### **Description**
- Add template parameter support to dashboard API requests

- Assign specific templates to different data categories

- Modify `safeGet` function to include template parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dashboard API Requests"] --> B["safeGet Function"]
  B --> C["Template Parameter"]
  C --> D["Planta y Contratos"]
  C --> E["Neikes y Becas"]
  D --> F["Regular Agent Data"]
  E --> G["NeikeBeca Agent Data"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DashboardPage.jsx</strong><dd><code>Add template parameter to dashboard API calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/page/DashboardPage.jsx

<ul><li>Modified <code>safeGet</code> function to accept template parameter<br> <li> Added template constants for data categorization<br> <li> Updated all API calls to include appropriate templates<br> <li> Assigned 'Planta y Contratos' to regular agent endpoints<br> <li> Assigned 'Neikes y Becas' to NeikeBeca endpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/CarlosJFer/AnalisisDeDotacion/pull/29/files#diff-199a170f9a4dbc9b17cd15b0a5be3e781323e267df32251a101439693cc24c91">+31/-25</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

