### PR TITLE
feat: soportar plantillas en DashboardPage

### DIFF
--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -46,7 +46,7 @@ const DashboardPage = () => {
     const [agentsByDepartamento, setAgentsByDepartamento] = useState([]);
     const [agentsByDivision, setAgentsByDivision] = useState([]);
 
-    // Datos para Neikes y Becas
+    // Datos para Neikes y Beca
     const [agentsByFunctionNeikeBeca, setAgentsByFunctionNeikeBeca] = useState([]);
     const [agentsByEmploymentTypeNeikeBeca, setAgentsByEmploymentTypeNeikeBeca] = useState([]);
     const [ageDistributionNeikeBeca, setAgeDistributionNeikeBeca] = useState(null);
@@ -98,13 +98,26 @@ const DashboardPage = () => {
             const funcRes = await apiClient.get('/functions');
             const funcs = funcRes.data.reduce((acc, f) => { acc[f.name] = f.endpoint; return acc; }, {});
 
-            const safeGet = (endpoint, defaultData) => {
+            const safeGet = (endpoint, defaultData, plantilla) => {
                 if (!endpoint) return Promise.resolve({ data: defaultData });
+                const params = { ...appliedFilters };
+                if (plantilla) {
+                    params.plantilla = plantilla;
+                }
                 return apiClient
-                    .get(endpoint, { params: appliedFilters })
+                    .get(endpoint, { params })
                     .catch(() => ({ data: defaultData }));
             };
 
+            // Ajustar nombres de plantillas a los mismos usados en el backend.
+            // Cuando no se envía parámetro de plantilla, el backend utiliza
+            // por defecto "Rama completa - Planta".  Las estadísticas
+            // específicas de Neikes y Beca se guardan con la plantilla
+            // "Rama completa - Neikes y Beca".  Por lo tanto, para
+            // filtrar correctamente los datos según la plantilla debemos
+            // pasar estas cadenas exactas en la query.
+            const TEMPLATE_PLANTA_CONTRATOS = 'Rama completa - Planta';
+            const TEMPLATE_NEIKES_BECAS = 'Rama completa - Neikes y Beca';
             const [
                 totalResponse,
                 ageDistResponse,
@@ -130,29 +143,32 @@ const DashboardPage = () => {
                 departamentoNeikeBecaResponse,
                 divisionNeikeBecaResponse
             ] = await Promise.all([
-                safeGet(funcs.totalAgents, { total: 0 }),
-                safeGet(funcs.ageDistribution, null),
-                safeGet(funcs.ageByFunction, []),
-                safeGet(funcs.agentsByFunction, []),
-                safeGet(funcs.agentsByEmploymentType, []),
-                safeGet(funcs.agentsByDependency, []),
-                safeGet(funcs.agentsBySecretaria, []),
-                safeGet(funcs.agentsBySubsecretaria, []),
-                safeGet(funcs.agentsByDireccionGeneral, []),
-                safeGet(funcs.agentsByDireccion, []),
-                safeGet(funcs.agentsByDepartamento, []),
-                safeGet(funcs.agentsByDivision, []),
-                safeGet(funcs.agentsByFunctionNeikeBeca, []),
-                safeGet(funcs.agentsByEmploymentTypeNeikeBeca, []),
-                safeGet(funcs.ageDistributionNeikeBeca, null),
-                safeGet(funcs.ageByFunctionNeikeBeca, []),
-                safeGet(funcs.agentsByDependencyNeikeBeca, []),
-                safeGet(funcs.agentsBySecretariaNeikeBeca, []),
-                safeGet(funcs.agentsBySubsecretariaNeikeBeca, []),
-                safeGet(funcs.agentsByDireccionGeneralNeikeBeca, []),
-                safeGet(funcs.agentsByDireccionNeikeBeca, []),
-                safeGet(funcs.agentsByDepartamentoNeikeBeca, []),
-                safeGet(funcs.agentsByDivisionNeikeBeca, [])
+                // Datos generales correspondientes a la plantilla "Rama completa - Planta"
+                safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.ageDistribution, null, TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.ageByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByEmploymentType, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDependency, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsBySecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsBySubsecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDireccionGeneral, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDireccion, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDepartamento, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcs.agentsByDivision, [], TEMPLATE_PLANTA_CONTRATOS),
+                // Para Neikes y Beca reutilizamos los mismos endpoints que para Planta,
+                // pero pasando el parámetro "plantilla" igual a 'Rama completa - Neikes y Beca'.
+                safeGet(funcs.agentsByFunction, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByEmploymentType, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.ageDistribution, null, TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.ageByFunction, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDependency, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsBySecretaria, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsBySubsecretaria, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDireccionGeneral, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDireccion, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDepartamento, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDivision, [], TEMPLATE_NEIKES_BECAS)
             ]);
 
             setTotalAgents(totalResponse.data.total);
@@ -377,7 +393,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={4}>
                         <CustomDonutChart
                             data={agentsByEmploymentTypeNeikeBeca}
-                            title="Agentes por Situación de Revista - Neikes y Becas"
+                            title="Agentes por Situación de Revista - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="type"
@@ -423,7 +439,7 @@ const DashboardPage = () => {
                                 data={ageDistributionNeikeBeca.rangeData}
                                 xKey="range"
                                 barKey="count"
-                                title="Distribución por Rangos de Edad - Neikes y Becas"
+                                title="Distribución por Rangos de Edad - Neikes y Beca"
                                 isDarkMode={isDarkMode}
                             />
                         ) : (
@@ -469,7 +485,7 @@ const DashboardPage = () => {
                         {ageDistributionNeikeBeca ? (
                             <CustomAreaChart
                                 data={ageDistributionNeikeBeca.rangeData}
-                                title="Distribución por Rangos de Edad según el área - Neikes y Becas"
+                                title="Distribución por Rangos de Edad según el área - Neikes y Beca"
                                 isDarkMode={isDarkMode}
                                 xKey="range"
                                 yKey="count"
@@ -486,7 +502,7 @@ const DashboardPage = () => {
                                 data={ageByFunctionNeikeBeca.filter(f => f.function && f.function.trim() !== '' && f.function.trim() !== '-').slice(0, 10)}
                                 xKey="function"
                                 barKey="avgAge"
-                                title="Edad Promedio por Función (Top 10) - Neikes y Becas"
+                                title="Edad Promedio por Función (Top 10) - Neikes y Beca"
                                 isDarkMode={isDarkMode}
                             />
                         ) : (
@@ -510,7 +526,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} md={6}>
                         <CustomDonutChart
                             data={agentsBySecretaria.slice(0, 8)}
-                            title="Agentes por Secretaría (Top 8) - Planta y Contrato"
+                            title="Agentes por Secretaría (Top 8) - Planta y Contratos"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="secretaria"
@@ -519,7 +535,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} md={6}>
                         <CustomDonutChart
                             data={agentsByDependency.slice(0, 8)}
-                            title="Agentes por Dependencia (Top 8) - Planta y Contrato"
+                            title="Agentes por Dependencia (Top 8) - Planta y Contratos"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="dependency"
@@ -528,7 +544,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} md={6}>
                         <CustomDonutChart
                             data={agentsBySecretariaNeikeBeca.slice(0, 8)}
-                            title="Agentes por Secretaría (Top 8) - Neikes y Becas"
+                            title="Agentes por Secretaría (Top 8) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="secretaria"
@@ -537,7 +553,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} md={6}>
                         <CustomDonutChart
                             data={agentsByDependencyNeikeBeca.slice(0, 8)}
-                            title="Agentes por Dependencia (Top 8) - Neikes y Becas"
+                            title="Agentes por Dependencia (Top 8) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="dependency"
@@ -549,7 +565,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsBySubsecretaria, 'subsecretaria').slice(0, 10)}
                             xKey="subsecretaria"
                             barKey="count"
-                            title="Agentes por Subsecretaría (Top 10) - Planta y Contrato"
+                            title="Agentes por Subsecretaría (Top 10) - Planta y Contratos"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -559,7 +575,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsBySubsecretariaNeikeBeca, 'subsecretaria').slice(0, 10)}
                             xKey="subsecretaria"
                             barKey="count"
-                            title="Agentes por Subsecretaría (Top 10) - Neikes y Becas"
+                            title="Agentes por Subsecretaría (Top 10) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -576,7 +592,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsByDireccionGeneral, 'direccionGeneral').slice(0, 10)}
                             xKey="direccionGeneral"
                             barKey="count"
-                            title="Agentes por Dirección General (Top 10) - Planta y Contrato"
+                            title="Agentes por Dirección General (Top 10) - Planta y Contratos"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -586,7 +602,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsByDireccion, 'direccion').slice(0, 10)}
                             xKey="direccion"
                             barKey="count"
-                            title="Agentes por Dirección (Top 10) - Planta y Contrato"
+                            title="Agentes por Dirección (Top 10) - Planta y Contratos"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -596,7 +612,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsByDireccionGeneralNeikeBeca, 'direccionGeneral').slice(0, 10)}
                             xKey="direccionGeneral"
                             barKey="count"
-                            title="Agentes por Dirección General (Top 10) - Neikes y Becas"
+                            title="Agentes por Dirección General (Top 10) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -606,7 +622,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsByDireccionNeikeBeca, 'direccion').slice(0, 10)}
                             xKey="direccion"
                             barKey="count"
-                            title="Agentes por Dirección (Top 10) - Neikes y Becas"
+                            title="Agentes por Dirección (Top 10) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -615,7 +631,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={6}>
                         <CustomDonutChart
                             data={filterValidData(agentsByDepartamento, 'departamento').slice(0, 8)}
-                            title="Agentes por Departamento (Top 8) - Planta y Contrato"
+                            title="Agentes por Departamento (Top 8) - Planta y Contratos"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="departamento"
@@ -624,7 +640,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={6}>
                         <CustomDonutChart
                             data={filterValidData(agentsByDivision, 'division').slice(0, 8)}
-                            title="Agentes por División (Top 8) - Planta y Contrato"
+                            title="Agentes por División (Top 8) - Planta y Contratos"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="division"
@@ -633,7 +649,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={6}>
                         <CustomDonutChart
                             data={filterValidData(agentsByDepartamentoNeikeBeca, 'departamento').slice(0, 8)}
-                            title="Agentes por Departamento (Top 8) - Neikes y Becas"
+                            title="Agentes por Departamento (Top 8) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="departamento"
@@ -642,7 +658,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={6}>
                         <CustomDonutChart
                             data={filterValidData(agentsByDivisionNeikeBeca, 'division').slice(0, 8)}
-                            title="Agentes por División (Top 8) - Neikes y Becas"
+                            title="Agentes por División (Top 8) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="division"


### PR DESCRIPTION
### **User description**
## Summary
- aceptar parámetro de plantilla en las solicitudes del dashboard
- enviar nombres de plantilla correspondientes a Planta y Contratos y a Neikes y Beca

## Testing
- `npm test` *(falla: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d8419ca083279e6eb6ef49a5e8dc


___

### **PR Type**
Enhancement


___

### **Description**
- Add template parameter support to dashboard API requests

- Align template names with backend specifications

- Fix terminology from "Becas" to "Beca" throughout UI

- Update chart titles to use "Contratos" instead of "Contrato"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dashboard API Requests"] --> B["Template Parameter Added"]
  B --> C["Planta y Contratos Template"]
  B --> D["Neikes y Beca Template"]
  C --> E["Backend Alignment"]
  D --> E
  E --> F["Updated Chart Titles"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DashboardPage.jsx</strong><dd><code>Template parameter support and naming alignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/page/DashboardPage.jsx

<ul><li>Add template parameter support to <code>safeGet</code> function for API requests<br> <li> Define template constants for "Rama completa - Planta" and "Rama <br>completa - Neikes y Beca"<br> <li> Update all API calls to use appropriate template parameters<br> <li> Fix terminology from "Becas" to "Beca" in comments and chart titles<br> <li> Change "Contrato" to "Contratos" in chart titles for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/CarlosJFer/AnalisisDeDotacion/pull/31/files#diff-199a170f9a4dbc9b17cd15b0a5be3e781323e267df32251a101439693cc24c91">+60/-44</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

