### PR TITLE
feat: soportar plantillas en DashboardPage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import NotificationProvider from './context/NotificationContext.jsx';
 // Páginas (lazy loading)
 const LoginPage = lazy(() => import('./page/LoginPage.jsx'));
 const DashboardPage = lazy(() => import('./page/DashboardPage.jsx'));
+const DashboardNeikeBeca = lazy(() => import('./page/DashboardNeikeBeca.jsx'));
 const AdminPage = lazy(() => import('./page/AdminPage.jsx'));
 const UserAdminPage = lazy(() => import('./page/UserAdminPage.jsx'));
 const SecretariaAdminPage = lazy(() => import('./page/SecretariaAdminPage.jsx'));
@@ -58,6 +59,7 @@ const AppLayout = () => {
             {/* Rutas Protegidas para Usuarios */}
             <Route element={<ProtectedRoute />}> 
               <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/dashboard-neike-beca" element={<DashboardNeikeBeca />} />
               <Route path="/comparacion" element={<ComparisonPage />} />
               <Route path="/change-password" element={<ChangePasswordPage />} />
               <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/DependencyFilter.jsx
+++ b/frontend/src/components/DependencyFilter.jsx
@@ -11,8 +11,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import { OptimizedTextField } from './OptimizedFormField.jsx';
 import { useTheme } from '../context/ThemeContext.jsx';
 
+// Eliminar el campo dependencia del filtro por solicitud del usuario
 const defaultFilters = {
-  dependencia: '',
   secretaria: '',
   subsecretaria: '',
   direccionGeneral: '',
@@ -60,23 +60,17 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
             sx={{
               width: 32,
               height: 32,
-              background: 'linear-gradient(135deg, #4caf50, #388e3c)',
+              background: 'linear-gradient(135deg, #2196f3, #1976d2)',
             }}
           >
             <SearchIcon sx={{ fontSize: 18 }} />
           </Avatar>
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
-            Filtrar dependencia
+            Filtrar datos
           </Typography>
         </Box>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'flex-end' }}>
-          <OptimizedTextField
-            name="dependencia"
-            label="Dependencia"
-            value={localFilters.dependencia}
-            onChange={handleChange}
-            sx={{ minWidth: 200 }}
-          />
+          {/* Campo Dependencia eliminado */}
           <OptimizedTextField
             name="secretaria"
             label="Secretaría"
@@ -130,11 +124,18 @@ const DependencyFilter = ({ filters = defaultFilters, onFilter }) => {
             variant="contained"
             onClick={handleSubmit}
             sx={{
-              background: 'linear-gradient(135deg, #4caf50, #388e3c)',
+              background: 'linear-gradient(135deg, #2196f3, #1976d2)',
               color: 'white',
+              fontWeight: 600,
+              px: 3,
+              py: 1.5,
+              borderRadius: 3,
+              textTransform: 'none',
               mt: { xs: 2, sm: 0 },
               '&:hover': {
-                background: 'linear-gradient(135deg, #388e3c, #2e7d32)',
+                background: 'linear-gradient(135deg, #1976d2, #1565c0)',
+                transform: 'translateY(-2px)',
+                boxShadow: '0 6px 20px rgba(33, 150, 243, 0.3)',
               },
             }}
           >

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -12,6 +12,7 @@ import Chip from '@mui/material/Chip';
 import HomeIcon from '@mui/icons-material/Home';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize';
+import AnalyticsIcon from '@mui/icons-material/Analytics';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import LogoutIcon from '@mui/icons-material/Logout';
 import PersonIcon from '@mui/icons-material/Person';
@@ -122,7 +123,7 @@ const Navbar = () => {
             </Button>
           )}
           
-          {/* Botón Dashboard */}
+          {/* Botón Dashboard - Planta y Contratos */}
           {user && (
             <Button
               component={Link}
@@ -155,11 +156,48 @@ const Navbar = () => {
                 transition: 'all 0.3s ease',
               }}
             >
-              Dashboard
+              Dashboard - Planta y Contratos
             </Button>
           )}
 
-          {/* Botón Funciones */}
+          {/* Botón Dashboard - Neikes y Becas */}
+          {user && (
+            <Button
+              component={Link}
+              to="/dashboard-neike-beca"
+              startIcon={<AnalyticsIcon />}
+              sx={{
+                color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+                fontWeight: 600,
+                px: 3,
+                py: 1.5,
+                borderRadius: 3,
+                textTransform: 'none',
+                fontSize: '0.9rem',
+                background: isDarkMode
+                  ? 'rgba(255, 255, 255, 0.05)'
+                  : 'rgba(255, 255, 255, 0.7)',
+                border: isDarkMode
+                  ? '1px solid rgba(255, 255, 255, 0.1)'
+                  : '1px solid rgba(0, 0, 0, 0.08)',
+                '&:hover': {
+                  background: isDarkMode
+                    ? 'rgba(33, 150, 243, 0.2)'
+                    : 'rgba(33, 150, 243, 0.15)',
+                  color: isDarkMode ? '#64b5f6' : '#1976d2',
+                  transform: 'translateY(-2px)',
+                  boxShadow: isDarkMode
+                    ? '0 6px 20px rgba(33, 150, 243, 0.3)'
+                    : '0 6px 20px rgba(33, 150, 243, 0.2)',
+                },
+                transition: 'all 0.3s ease',
+              }}
+            >
+              Dashboard - Neikes y Becas
+            </Button>
+          )}
+
+          {/* Botón Herramientas */}
           {user && (
             <Button
               component={Link}
@@ -192,17 +230,17 @@ const Navbar = () => {
                 transition: 'all 0.3s ease',
               }}
             >
-              Funciones
+              Herramientas
             </Button>
           )}
           
           {/* Botón Panel de administración (solo admin) */}
           {user && user.role === 'admin' && (
-            <Button 
-              component={Link} 
+            <Button
+              component={Link}
               to="/admin"
               startIcon={<AdminPanelSettingsIcon />}
-              sx={{ 
+              sx={{
                 color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
                 fontWeight: 600,
                 px: 3,
@@ -210,15 +248,15 @@ const Navbar = () => {
                 borderRadius: 3,
                 textTransform: 'none',
                 fontSize: '0.9rem',
-                background: isDarkMode 
-                  ? 'rgba(255, 255, 255, 0.05)' 
+                background: isDarkMode
+                  ? 'rgba(255, 255, 255, 0.05)'
                   : 'rgba(255, 255, 255, 0.7)',
                 border: isDarkMode
                   ? '1px solid rgba(255, 255, 255, 0.1)'
                   : '1px solid rgba(0, 0, 0, 0.08)',
                 '&:hover': {
-                  background: isDarkMode 
-                    ? 'rgba(156, 39, 176, 0.2)' 
+                  background: isDarkMode
+                    ? 'rgba(156, 39, 176, 0.2)'
                     : 'rgba(156, 39, 176, 0.15)',
                   color: isDarkMode ? '#ba68c8' : '#7b1fa2',
                   transform: 'translateY(-2px)',
@@ -232,111 +270,116 @@ const Navbar = () => {
               Panel de Administración
             </Button>
           )}
+        </Box>
 
-          
-          {user ? (
-            <>
-              {/* Información del usuario */}
-              <Box sx={{ 
-                display: 'flex', 
-                alignItems: 'center', 
-                gap: 1.5, 
+        {user ? (
+          <>
+            {/* Información del usuario */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
                 mx: 2,
                 px: 2,
                 py: 1,
                 borderRadius: 3,
-                background: isDarkMode 
-                  ? 'rgba(255, 255, 255, 0.05)' 
+                background: isDarkMode
+                  ? 'rgba(255, 255, 255, 0.05)'
                   : 'rgba(255, 255, 255, 0.7)',
                 border: isDarkMode
                   ? '1px solid rgba(255, 255, 255, 0.1)'
                   : '1px solid rgba(0, 0, 0, 0.08)',
-              }}>
-                <Avatar sx={{ 
-                  width: 32, 
+              }}
+            >
+              <Avatar
+                sx={{
+                  width: 32,
                   height: 32,
-                  background: user.role === 'admin' 
+                  background: user.role === 'admin'
                     ? 'linear-gradient(135deg, #ff9800, #f57c00)'
                     : 'linear-gradient(135deg, #2196f3, #1976d2)',
                   fontSize: '0.9rem',
                   fontWeight: 600,
-                }}>
-                  {user.role === 'admin' ? <AdminPanelSettingsIcon sx={{ fontSize: 18 }} /> : <PersonIcon sx={{ fontSize: 18 }} />}
-                </Avatar>
-                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
-                  <Typography 
-                    variant="body2"
-                    sx={{ 
-                      color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-                      fontSize: '0.85rem',
-                      fontWeight: 600,
-                      lineHeight: 1.2,
-                    }}
-                  >
-                    {user.username}
-                  </Typography>
-                  <Chip 
-                    label={user.role === 'admin' ? 'Administrador' : 'Usuario'}
-                    size="small"
-                    sx={{
-                      height: 16,
-                      fontSize: '0.65rem',
-                      fontWeight: 600,
-                      background: user.role === 'admin' 
-                        ? 'linear-gradient(135deg, #ff9800, #f57c00)'
-                        : 'linear-gradient(135deg, #2196f3, #1976d2)',
-                      color: 'white',
-                      '& .MuiChip-label': {
-                        px: 1,
-                      }
-                    }}
-                  />
-                </Box>
-              </Box>
-
-              <ProfileMenu />
-
-              <NotificationBell />
-
-              <ThemeToggle />
-              
-              <Button 
-                onClick={logout}
-                startIcon={<LogoutIcon />}
-                sx={{ 
-                  color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-                  fontWeight: 600,
-                  px: 3,
-                  py: 1.5,
-                  borderRadius: 3,
-                  textTransform: 'none',
-                  fontSize: '0.9rem',
-                  background: isDarkMode 
-                    ? 'rgba(255, 255, 255, 0.05)' 
-                    : 'rgba(255, 255, 255, 0.7)',
-                  border: isDarkMode
-                    ? '1px solid rgba(255, 255, 255, 0.1)'
-                    : '1px solid rgba(0, 0, 0, 0.08)',
-                  '&:hover': {
-                    background: isDarkMode 
-                      ? 'rgba(244, 67, 54, 0.2)' 
-                      : 'rgba(244, 67, 54, 0.15)',
-                    color: isDarkMode ? '#ef5350' : '#d32f2f',
-                    transform: 'translateY(-2px)',
-                    boxShadow: isDarkMode
-                      ? '0 6px 20px rgba(244, 67, 54, 0.3)'
-                      : '0 6px 20px rgba(244, 67, 54, 0.2)',
-                  },
-                  transition: 'all 0.3s ease',
                 }}
               >
-                Salir
-              </Button>
-            </>
-          ) : (
-            null
-          )}
-        </Box>
+                {user.role === 'admin' ? (
+                  <AdminPanelSettingsIcon sx={{ fontSize: 18 }} />
+                ) : (
+                  <PersonIcon sx={{ fontSize: 18 }} />
+                )}
+              </Avatar>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                <Typography
+                  variant="body2"
+                  sx={{
+                    color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+                    fontSize: '0.85rem',
+                    fontWeight: 600,
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {user.username}
+                </Typography>
+                <Chip
+                  label={user.role === 'admin' ? 'Administrador' : 'Usuario'}
+                  size="small"
+                  sx={{
+                    height: 16,
+                    fontSize: '0.65rem',
+                    fontWeight: 600,
+                    background: user.role === 'admin'
+                      ? 'linear-gradient(135deg, #ff9800, #f57c00)'
+                      : 'linear-gradient(135deg, #2196f3, #1976d2)',
+                    color: 'white',
+                    '& .MuiChip-label': {
+                      px: 1,
+                    },
+                  }}
+                />
+              </Box>
+            </Box>
+
+            <ProfileMenu />
+
+            <NotificationBell />
+
+            <ThemeToggle />
+
+            <Button
+              onClick={logout}
+              startIcon={<LogoutIcon />}
+              sx={{
+                color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+                fontWeight: 600,
+                px: 3,
+                py: 1.5,
+                borderRadius: 3,
+                textTransform: 'none',
+                fontSize: '0.9rem',
+                background: isDarkMode
+                  ? 'rgba(255, 255, 255, 0.05)'
+                  : 'rgba(255, 255, 255, 0.7)',
+                border: isDarkMode
+                  ? '1px solid rgba(255, 255, 255, 0.1)'
+                  : '1px solid rgba(0, 0, 0, 0.08)',
+                '&:hover': {
+                  background: isDarkMode
+                    ? 'rgba(244, 67, 54, 0.2)'
+                    : 'rgba(244, 67, 54, 0.15)',
+                  color: isDarkMode ? '#ef5350' : '#d32f2f',
+                  transform: 'translateY(-2px)',
+                  boxShadow: isDarkMode
+                    ? '0 6px 20px rgba(244, 67, 54, 0.3)'
+                    : '0 6px 20px rgba(244, 67, 54, 0.2)',
+                },
+                transition: 'all 0.3s ease',
+              }}
+            >
+              Salir
+            </Button>
+          </>
+        ) : null}
       </Toolbar>
     </AppBar>
   );

--- a/frontend/src/page/DashboardNeikeBeca.jsx
+++ b/frontend/src/page/DashboardNeikeBeca.jsx
@@ -13,7 +13,7 @@ import CustomDonutChart from '../components/CustomDonutChart';
 import CustomAreaChart from '../components/CustomAreaChart';
 import DependencyFilter from '../components/DependencyFilter.jsx';
 
-const DashboardPage = () => {
+const DashboardNeikeBeca = () => {
     const { user } = useAuth();
     const { isDarkMode } = useTheme();
     const [loading, setLoading] = useState(true);
@@ -102,8 +102,8 @@ const DashboardPage = () => {
 
             // Ajustar nombres de plantillas a los mismos usados en el backend.
             // Este dashboard debe consultar únicamente los datos cargados
-            // con la plantilla "Rama completa - Planta y Contratos".
-            const TEMPLATE_PLANTA_CONTRATOS = 'Rama completa - Planta y Contratos';
+            // con la plantilla "Rama completa - Neikes y Beca".
+            const TEMPLATE_NEIKES_BECAS = 'Rama completa - Neikes y Beca';
             const [
                 totalData,
                 ageDistData,
@@ -118,19 +118,19 @@ const DashboardPage = () => {
                 departamentoData,
                 divisionData
             ] = await Promise.all([
-                // Datos generales correspondientes a la plantilla "Rama completa - Planta y Contratos"
-                safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.ageDistribution, null, TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.ageByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByEmploymentType, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDependency, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsBySecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsBySubsecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDireccionGeneral, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDireccion, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDepartamento, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDivision, [], TEMPLATE_PLANTA_CONTRATOS)
+                // Datos correspondientes a la plantilla "Rama completa - Neikes y Beca"
+                safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.ageDistribution, null, TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.ageByFunction, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByFunction, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByEmploymentType, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDependency, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsBySecretaria, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsBySubsecretaria, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDireccionGeneral, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDireccion, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDepartamento, [], TEMPLATE_NEIKES_BECAS),
+                safeGet(funcs.agentsByDivision, [], TEMPLATE_NEIKES_BECAS)
             ]);
 
             setTotalAgents(totalData.total);
@@ -232,7 +232,7 @@ const DashboardPage = () => {
                     mb: 1,
                 }}
             >
-                Dashboard - Planta y Contratos
+                Dashboard - Neikes y Becas
             </Typography>
             <Typography
                 variant="h6"
@@ -317,7 +317,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={8}>
                         <CustomDonutChart
                             data={agentsByFunction.filter(f => f.function && f.function.trim() !== '' && f.function.trim() !== '-').slice(0, 10)}
-                            title="Distribución de Agentes por Función (Top 10) - Planta y Contratos"
+                            title="Distribución de Agentes por Función (Top 10) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="function"
@@ -326,7 +326,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={4}>
                         <CustomDonutChart
                             data={agentsByEmploymentType}
-                            title="Agentes por Situación de Revista - Planta y Contratos"
+                            title="Agentes por Situación de Revista - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="type"
@@ -356,7 +356,7 @@ const DashboardPage = () => {
                                 data={ageDistribution.rangeData}
                                 xKey="range"
                                 barKey="count"
-                                title="Distribución por Rangos de Edad - Planta y Contratos"
+                                title="Distribución por Rangos de Edad - Neikes y Beca"
                                 isDarkMode={isDarkMode}
                             />
                         ) : (
@@ -372,7 +372,7 @@ const DashboardPage = () => {
                         {ageDistribution ? (
                             <CustomAreaChart
                                 data={ageDistribution.rangeData}
-                                title="Distribución por Rangos de Edad según el área - Planta y Contratos"
+                                title="Distribución por Rangos de Edad según el área - Neikes y Beca"
                                 isDarkMode={isDarkMode}
                                 xKey="range"
                                 yKey="count"
@@ -389,7 +389,7 @@ const DashboardPage = () => {
                                 data={ageByFunction.filter(f => f.function && f.function.trim() !== '' && f.function.trim() !== '-').slice(0, 10)}
                                 xKey="function"
                                 barKey="avgAge"
-                                title="Edad Promedio por Función (Top 10) - Planta y Contratos"
+                                title="Edad Promedio por Función (Top 10) - Neikes y Beca"
                                 isDarkMode={isDarkMode}
                             />
                         ) : (
@@ -413,7 +413,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} md={6}>
                         <CustomDonutChart
                             data={agentsBySecretaria.slice(0, 8)}
-                            title="Agentes por Secretaría (Top 8) - Planta y Contratos"
+                            title="Agentes por Secretaría (Top 8) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="secretaria"
@@ -422,7 +422,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} md={6}>
                         <CustomDonutChart
                             data={agentsByDependency.slice(0, 8)}
-                            title="Agentes por Dependencia (Top 8) - Planta y Contratos"
+                            title="Agentes por Dependencia (Top 8) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="dependency"
@@ -434,7 +434,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsBySubsecretaria, 'subsecretaria').slice(0, 10)}
                             xKey="subsecretaria"
                             barKey="count"
-                            title="Agentes por Subsecretaría (Top 10) - Planta y Contratos"
+                            title="Agentes por Subsecretaría (Top 10) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -451,7 +451,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsByDireccionGeneral, 'direccionGeneral').slice(0, 10)}
                             xKey="direccionGeneral"
                             barKey="count"
-                            title="Agentes por Dirección General (Top 10) - Planta y Contratos"
+                            title="Agentes por Dirección General (Top 10) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -461,7 +461,7 @@ const DashboardPage = () => {
                             data={filterValidData(agentsByDireccion, 'direccion').slice(0, 10)}
                             xKey="direccion"
                             barKey="count"
-                            title="Agentes por Dirección (Top 10) - Planta y Contratos"
+                            title="Agentes por Dirección (Top 10) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             height={400}
                         />
@@ -470,7 +470,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={6}>
                         <CustomDonutChart
                             data={filterValidData(agentsByDepartamento, 'departamento').slice(0, 8)}
-                            title="Agentes por Departamento (Top 8) - Planta y Contratos"
+                            title="Agentes por Departamento (Top 8) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="departamento"
@@ -479,7 +479,7 @@ const DashboardPage = () => {
                     <Grid item xs={12} lg={6}>
                         <CustomDonutChart
                             data={filterValidData(agentsByDivision, 'division').slice(0, 8)}
-                            title="Agentes por División (Top 8) - Planta y Contratos"
+                            title="Agentes por División (Top 8) - Neikes y Beca"
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="division"
@@ -527,4 +527,5 @@ const DashboardPage = () => {
     );
 };
 
-export default DashboardPage;
+export default DashboardNeikeBeca;
+


### PR DESCRIPTION
## Summary
- aceptar parámetro de plantilla en las solicitudes del dashboard
- enviar nombres de plantilla correspondientes a Planta y Contratos y a Neikes y Beca
- manejar respuestas faltantes del backend evitando errores al acceder a `data`
- crear un dashboard independiente para la plantilla de Neikes y Becas
- eliminar el campo de dependencia del filtro de dashboard
- dividir los dashboards para Planta y Contratos y para Neikes y Becas con rutas y acceso desde la barra de navegación
- renombrar opciones del menú y aplicar estilos modernos en filtros
- consultar exclusivamente la plantilla correspondiente en cada dashboard
- cerrar el contenedor del menú de navegación en `Navbar` y mover la sección de perfil fuera para evitar errores de JSX

## Testing
- `npm test` *(falla: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4d8419ca083279e6eb6ef49a5e8dc