### PR TITLE
Align organigram tooltips and add dashboard navigation button

### DIFF
--- a/frontend/src/components/OptimizedOrganigramaTreeView.jsx
+++ b/frontend/src/components/OptimizedOrganigramaTreeView.jsx
@@ -9,6 +9,7 @@ import WarningIcon from '@mui/icons-material/Warning';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import ArrowCircleRightOutlinedIcon from '@mui/icons-material/ArrowCircleRightOutlined';
 import { useImperativeHandle, forwardRef } from "react";
 import { useTheme } from '../context/ThemeContext.jsx';
 
@@ -182,7 +183,7 @@ const TreeNode = memo(({
           alignItems: 'center',
           gap: 1,
           py: 0.25, // Padding vertical reducido
-        }} onClick={(e) => { e.stopPropagation(); onNodeSelect && onNodeSelect(node); }}>
+        }}>
           <Avatar 
             sx={{ 
               width: avatarSize, 
@@ -219,21 +220,36 @@ const TreeNode = memo(({
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             {estado && tooltipContent && (
               <Tooltip title={tooltipContent} placement="right" enterDelay={300}>
-                <Box sx={{ cursor: 'help' }}>
+                <Box sx={{ cursor: 'help', display: 'flex', alignItems: 'center' }}>
                   <EstadoIcon estado={estado} />
                 </Box>
               </Tooltip>
             )}
-            
-            {node.funcion && node.funcion.trim() && (
+
+            {node.funcion && node.funcion.trim() && node.nombre !== 'Municipalidad' && (
               <Tooltip title={funcionTooltip} placement="right" enterDelay={300}>
-                <InfoOutlinedIcon 
-                  fontSize="small" 
-                  sx={{ 
-                    color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
-                    cursor: 'help',
-                  }} 
-                />
+                <Box sx={{ cursor: 'help', display: 'flex', alignItems: 'center' }}>
+                  <InfoOutlinedIcon
+                    fontSize="small"
+                    sx={{
+                      color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
+                    }}
+                  />
+                </Box>
+              </Tooltip>
+            )}
+
+            {onNodeSelect && (
+              <Tooltip title="Ver en dashboard" placement="right" enterDelay={300}>
+                <Box
+                  sx={{ cursor: 'pointer', display: 'flex', alignItems: 'center' }}
+                  onClick={(e) => { e.stopPropagation(); onNodeSelect(node); }}
+                >
+                  <ArrowCircleRightOutlinedIcon
+                    fontSize="small"
+                    sx={{ color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)' }}
+                  />
+                </Box>
               </Tooltip>
             )}
           </Box>

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -12,10 +12,12 @@ import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
 import CustomAreaChart from '../components/CustomAreaChart';
 import DependencyFilter from '../components/DependencyFilter.jsx';
+import { useLocation } from 'react-router-dom';
 
 const DashboardPage = () => {
     const { user } = useAuth();
     const { isDarkMode } = useTheme();
+    const location = useLocation();
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
     const [tabValue, setTabValue] = useState(0);
@@ -161,8 +163,25 @@ const DashboardPage = () => {
     };
 
     useEffect(() => {
+        if (location.state && location.state.nombre && location.state.nivel) {
+            const levelMap = {
+                1: 'secretaria',
+                2: 'subsecretaria',
+                3: 'direccionGeneral',
+                4: 'direccion',
+                5: 'departamento',
+                6: 'division'
+            };
+            const field = levelMap[location.state.nivel];
+            if (field) {
+                const newFilters = { ...filters, [field]: location.state.nombre };
+                setFilters(newFilters);
+                fetchAllData(newFilters);
+                return;
+            }
+        }
         fetchAllData(filters);
-    }, []);
+    }, [location.state]);
 
     const getTabButtonStyles = (value) => ({
         color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',

--- a/frontend/src/page/OrganigramaPage.jsx
+++ b/frontend/src/page/OrganigramaPage.jsx
@@ -320,7 +320,7 @@ const OrganigramaPage = () => {
             tree={filteredTree}
             getVariablesForNode={getVariablesForNode}
             searchTerm={search}
-            onNodeSelect={(node) => navigate('/dashboard', { state: { dependencia: node.nombre } })}
+            onNodeSelect={(node) => navigate('/dashboard', { state: { nombre: node.nombre, nivel: node.nivel } })}
           />
         )
       )}


### PR DESCRIPTION
### **User description**
## Summary
- Align indicator and info tooltips and avoid info tooltip on main municipality node
- Replace node click navigation with arrow button that links to dashboard
- Prefill dashboard filters based on selected organigram node

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mapbox-gl)*
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a731270b4483279ff25708b9827a1e


___

### **PR Type**
Enhancement


___

### **Description**
- Align organigram tooltips and improve visual consistency

- Replace node click navigation with dedicated arrow button

- Prefill dashboard filters based on organigram node selection

- Hide info tooltip for main municipality node


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Organigram Node"] --> B["Arrow Button Click"]
  B --> C["Dashboard Navigation"]
  C --> D["Prefilled Filters"]
  A --> E["Aligned Tooltips"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OptimizedOrganigramaTreeView.jsx</strong><dd><code>Refactor node tooltips and add navigation button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/OptimizedOrganigramaTreeView.jsx

<ul><li>Import <code>ArrowCircleRightOutlinedIcon</code> for navigation button<br> <li> Remove click handler from main node label container<br> <li> Wrap tooltip icons in flex containers for alignment<br> <li> Add conditional logic to hide info tooltip for municipality node<br> <li> Replace node click with dedicated arrow button for dashboard <br>navigation</ul>


</details>


  </td>
  <td><a href="https://github.com/CarlosJFer/AnalisisDeDotacion/pull/45/files#diff-cc7ec7ca503ed3fcb68000f6045654964cbf9a52f0515270abd455077b898bf5">+27/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DashboardPage.jsx</strong><dd><code>Add organigram state-based filter prefilling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/page/DashboardPage.jsx

<ul><li>Import <code>useLocation</code> hook from react-router-dom<br> <li> Add location state handling in useEffect<br> <li> Map organigram node levels to filter fields<br> <li> Prefill dashboard filters based on navigation state</ul>


</details>


  </td>
  <td><a href="https://github.com/CarlosJFer/AnalisisDeDotacion/pull/45/files#diff-199a170f9a4dbc9b17cd15b0a5be3e781323e267df32251a101439693cc24c91">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OrganigramaPage.jsx</strong><dd><code>Update navigation state parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/page/OrganigramaPage.jsx

<ul><li>Update navigation state to pass <code>nombre</code> and <code>nivel</code> instead of <br><code>dependencia</code><br> <li> Modify onNodeSelect callback to include node level information</ul>


</details>


  </td>
  <td><a href="https://github.com/CarlosJFer/AnalisisDeDotacion/pull/45/files#diff-ed7a11a0ed4b5923c62547af9f251cb6a5577e8a5da273ac866a19d51ea663be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

