### PR TITLE
Align organigram tooltips and add dashboard navigation button

### DIFF
--- a/frontend/src/components/OptimizedOrganigramaTreeView.jsx
+++ b/frontend/src/components/OptimizedOrganigramaTreeView.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo, memo, useCallback, useState, useRef } from "react";
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
-import { Typography, Tooltip, Box, Avatar, Chip, Card } from "@mui/material";
+import { Typography, Tooltip, Box, Avatar, Chip, Card, IconButton } from "@mui/material";
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import BusinessIcon from '@mui/icons-material/Business';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
@@ -9,6 +9,7 @@ import WarningIcon from '@mui/icons-material/Warning';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import ArrowCircleRightOutlinedIcon from '@mui/icons-material/ArrowCircleRightOutlined';
 import { useImperativeHandle, forwardRef } from "react";
 import { useTheme } from '../context/ThemeContext.jsx';
 
@@ -182,7 +183,7 @@ const TreeNode = memo(({
           alignItems: 'center',
           gap: 1,
           py: 0.25, // Padding vertical reducido
-        }} onClick={(e) => { e.stopPropagation(); onNodeSelect && onNodeSelect(node); }}>
+        }}>
           <Avatar 
             sx={{ 
               width: avatarSize, 
@@ -219,21 +220,45 @@ const TreeNode = memo(({
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             {estado && tooltipContent && (
               <Tooltip title={tooltipContent} placement="right" enterDelay={300}>
-                <Box sx={{ cursor: 'help' }}>
+                <Box sx={{ cursor: 'help', display: 'flex', alignItems: 'center' }}>
                   <EstadoIcon estado={estado} />
                 </Box>
               </Tooltip>
             )}
-            
-            {node.funcion && node.funcion.trim() && (
-              <Tooltip title={funcionTooltip} placement="right" enterDelay={300}>
-                <InfoOutlinedIcon 
-                  fontSize="small" 
-                  sx={{ 
-                    color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
-                    cursor: 'help',
-                  }} 
-                />
+
+            {node.funcion && node.funcion.trim() && node.nombre !== 'Municipalidad' && (
+              <Tooltip title={funcionTooltip} placement="bottom" enterDelay={300}>
+                <Box sx={{ cursor: 'help', display: 'flex', alignItems: 'center' }}>
+                  <InfoOutlinedIcon
+                    fontSize="small"
+                    sx={{
+                      color: isDarkMode ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
+                    }}
+                  />
+                </Box>
+              </Tooltip>
+            )}
+
+            {onNodeSelect && node.nombre !== 'Municipalidad' && (
+              <Tooltip title="Ver en dashboard" placement="right" enterDelay={300}>
+                <IconButton
+                  size="small"
+                  onClick={(e) => { e.stopPropagation(); onNodeSelect(node); }}
+                  sx={{
+                    p: 0.5,
+                    color: '#fff',
+                    background: 'linear-gradient(135deg, #4caf50, #388e3c)',
+                    '&:hover': {
+                      background: 'linear-gradient(135deg, #66bb6a, #43a047)',
+                      transform: 'scale(1.05)',
+                    },
+                    boxShadow: isDarkMode
+                      ? '0 2px 8px rgba(0, 0, 0, 0.4)'
+                      : '0 2px 8px rgba(0, 0, 0, 0.2)',
+                  }}
+                >
+                  <ArrowCircleRightOutlinedIcon fontSize="small" sx={{ color: '#fff' }} />
+                </IconButton>
               </Tooltip>
             )}
           </Box>

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -12,10 +12,12 @@ import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
 import CustomAreaChart from '../components/CustomAreaChart';
 import DependencyFilter from '../components/DependencyFilter.jsx';
+import { useLocation } from 'react-router-dom';
 
 const DashboardPage = () => {
     const { user } = useAuth();
     const { isDarkMode } = useTheme();
+    const location = useLocation();
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
     const [tabValue, setTabValue] = useState(0);
@@ -161,8 +163,25 @@ const DashboardPage = () => {
     };
 
     useEffect(() => {
+        if (location.state && location.state.nombre && location.state.nivel) {
+            const levelMap = {
+                1: 'secretaria',
+                2: 'subsecretaria',
+                3: 'direccionGeneral',
+                4: 'direccion',
+                5: 'departamento',
+                6: 'division'
+            };
+            const field = levelMap[location.state.nivel];
+            if (field) {
+                const newFilters = { ...filters, [field]: location.state.nombre };
+                setFilters(newFilters);
+                fetchAllData(newFilters);
+                return;
+            }
+        }
         fetchAllData(filters);
-    }, []);
+    }, [location.state]);
 
     const getTabButtonStyles = (value) => ({
         color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',

--- a/frontend/src/page/OrganigramaPage.jsx
+++ b/frontend/src/page/OrganigramaPage.jsx
@@ -320,7 +320,7 @@ const OrganigramaPage = () => {
             tree={filteredTree}
             getVariablesForNode={getVariablesForNode}
             searchTerm={search}
-            onNodeSelect={(node) => navigate('/dashboard', { state: { dependencia: node.nombre } })}
+            onNodeSelect={(node) => navigate('/dashboard', { state: { nombre: node.nombre, nivel: node.nivel } })}
           />
         )
       )}


### PR DESCRIPTION
## Summary
- Remove dashboard navigation button from "Municipalidad" root node
- Display function info tooltip below and show dashboard tooltip to the right
- Style dashboard link as a green modern button matching navbar aesthetics

## Testing
- `npm install`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a731270b4483279ff25708b9827a1e