### PR TITLE
feat: add time data type for templates

### DIFF
--- a/backend/controllers/uploadController.js
+++ b/backend/controllers/uploadController.js
@@ -130,6 +130,25 @@ async function uploadFile(req, res) {
                   if (!isNaN(parsed)) value = new Date(parsed);
                 }
               }
+              if (mapping.dataType === 'Time') {
+                if (typeof value === 'number') {
+                  const t = xlsx.SSF.parse_date_code(value);
+                  if (t) {
+                    const h = String(t.h).padStart(2, '0');
+                    const m = String(t.m).padStart(2, '0');
+                    const s = String(t.s).padStart(2, '0');
+                    value = `${h}:${m}:${s}`;
+                  }
+                } else if (typeof value === 'string') {
+                  const d = new Date(`1970-01-01T${value}`);
+                  if (!isNaN(d.getTime())) {
+                    const h = String(d.getHours()).padStart(2, '0');
+                    const m = String(d.getMinutes()).padStart(2, '0');
+                    const s = String(d.getSeconds()).padStart(2, '0');
+                    value = `${h}:${m}:${s}`;
+                  }
+                }
+              }
               obj[mapping.variableName] = value;
             }
           });

--- a/backend/controllers/uploadController_fixed.js
+++ b/backend/controllers/uploadController_fixed.js
@@ -134,6 +134,25 @@ async function uploadFile(req, res) {
                   if (!isNaN(parsed)) value = new Date(parsed);
                 }
               }
+              if (mapping.dataType === 'Time') {
+                if (typeof value === 'number') {
+                  const t = xlsx.SSF.parse_date_code(value);
+                  if (t) {
+                    const h = String(t.h).padStart(2, '0');
+                    const m = String(t.m).padStart(2, '0');
+                    const s = String(t.s).padStart(2, '0');
+                    value = `${h}:${m}:${s}`;
+                  }
+                } else if (typeof value === 'string') {
+                  const d = new Date(`1970-01-01T${value}`);
+                  if (!isNaN(d.getTime())) {
+                    const h = String(d.getHours()).padStart(2, '0');
+                    const m = String(d.getMinutes()).padStart(2, '0');
+                    const s = String(d.getSeconds()).padStart(2, '0');
+                    value = `${h}:${m}:${s}`;
+                  }
+                }
+              }
               obj[mapping.variableName] = value;
             }
           });

--- a/backend/models/ImportTemplate.js
+++ b/backend/models/ImportTemplate.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const columnMappingSchema = new mongoose.Schema({
   columnHeader: { type: String, required: true }, // Ej: "Nombre del Agente" o la letra de la columna como "C"
   variableName: { type: String, required: true }, // El nombre del campo como lo guardaremos en la BD, ej: "nombreCompleto"
-  dataType: { type: String, enum: ['String', 'Number', 'Date'], default: 'String' } // Para saber cómo procesar el dato
+  dataType: { type: String, enum: ['String', 'Number', 'Date', 'Time'], default: 'String' } // Para saber cómo procesar el dato
 }, { _id: false });
 
 const importTemplateSchema = new mongoose.Schema({

--- a/frontend/src/page/GestionPlantillasPage.jsx
+++ b/frontend/src/page/GestionPlantillasPage.jsx
@@ -177,6 +177,7 @@ const TemplateModal = ({ isOpen, onClose, onSave, template, isDarkMode }) => {
                           <MenuItem value="String">Texto</MenuItem>
                           <MenuItem value="Number">Número</MenuItem>
                           <MenuItem value="Date">Fecha</MenuItem>
+                          <MenuItem value="Time">Hora</MenuItem>
                         </Select>
                       </FormControl>
                     </Grid>


### PR DESCRIPTION
## Summary
- add `Time` to allowed data types for import templates
- support parsing time values during Excel uploads
- expose `Hora` option when creating template mappings

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8773215c88327ac8d6940d86c7aa9