### PR TITLE
Add analytics for seniority, studies and certifications dashboards

### DIFF
--- a/backend/config/defaultFunctions.js
+++ b/backend/config/defaultFunctions.js
@@ -10,5 +10,15 @@ module.exports = [
   { name: 'agentsByDireccionGeneral', description: 'Agentes por dirección general', endpoint: '/analytics/agents/by-direccion-general' },
   { name: 'agentsByDireccion', description: 'Agentes por dirección', endpoint: '/analytics/agents/by-direccion' },
   { name: 'agentsByDepartamento', description: 'Agentes por departamento', endpoint: '/analytics/agents/by-departamento' },
-  { name: 'agentsByDivision', description: 'Agentes por división', endpoint: '/analytics/agents/by-division' }
+  { name: 'agentsByDivision', description: 'Agentes por división', endpoint: '/analytics/agents/by-division' },
+  { name: 'agentsBySeniority', description: 'Agentes por rangos de antigüedad', endpoint: '/analytics/agents/seniority' },
+  { name: 'agentsBySecondaryStudies', description: 'Agentes por estudios secundarios', endpoint: '/analytics/agents/secondary-studies' },
+  { name: 'agentsByTertiaryStudies', description: 'Agentes por estudios terciarios', endpoint: '/analytics/agents/tertiary-studies' },
+  { name: 'agentsByUniversityStudies', description: 'Agentes por estudios universitarios', endpoint: '/analytics/agents/university-studies' },
+  { name: 'agentsByTopSecretariasUniversity', description: 'Top secretarías con títulos universitarios', endpoint: '/analytics/agents/top-secretarias-university' },
+  { name: 'agentsByTopSecretariasTertiary', description: 'Top secretarías con títulos terciarios', endpoint: '/analytics/agents/top-secretarias-tertiary' },
+  { name: 'certificationsRegistrationType', description: 'Agentes por tipo de registración', endpoint: '/analytics/certifications/registration-type' },
+  { name: 'certificationsEntryTime', description: 'Agentes por horario de entrada', endpoint: '/analytics/certifications/entry-time' },
+  { name: 'certificationsExitTime', description: 'Agentes por horario de salida', endpoint: '/analytics/certifications/exit-time' },
+  { name: 'certificationsTopUnits', description: 'Top unidades de registración', endpoint: '/analytics/certifications/top-units' }
 ];

--- a/backend/config/initFunctions.js
+++ b/backend/config/initFunctions.js
@@ -2,14 +2,17 @@ const FunctionDefinition = require('../models/FunctionDefinition');
 const defaultFunctions = require('./defaultFunctions');
 
 async function initFunctions() {
-  const count = await FunctionDefinition.estimatedDocumentCount();
-  if (count === 0) {
-    try {
-      await FunctionDefinition.insertMany(defaultFunctions);
-      console.log('Funciones iniciales cargadas');
-    } catch (error) {
-      console.error('Error al cargar funciones iniciales:', error.message);
-    }
+  try {
+    // Inserta o actualiza cada función por su nombre para asegurar
+    // que las nuevas definiciones estén disponibles en la colección.
+    await Promise.all(
+      defaultFunctions.map(func =>
+        FunctionDefinition.updateOne({ name: func.name }, { $set: func }, { upsert: true })
+      )
+    );
+    console.log('Funciones sincronizadas');
+  } catch (error) {
+    console.error('Error al sincronizar funciones iniciales:', error.message);
   }
 }
 

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -33,6 +33,16 @@ const {
   getAgentsByDireccionNeikeBeca,
   getAgentsByDepartamentoNeikeBeca,
   getAgentsByDivisionNeikeBeca,
+  getAgentsBySeniority,
+  getAgentsBySecondaryStudies,
+  getAgentsByTertiaryStudies,
+  getAgentsByUniversityStudies,
+  getTopSecretariasByUniversity,
+  getTopSecretariasByTertiary,
+  getAgentsByRegistrationType,
+  getAgentsByEntryTime,
+  getAgentsByExitTime,
+  getTopRegistrationUnits,
   notifyDashboardModification
 } = require('../controllers/analyticsController');
 
@@ -58,6 +68,18 @@ router.get('/agents/by-direccion-general', authenticateToken, getAgentsByDirecci
 router.get('/agents/by-direccion', authenticateToken, getAgentsByDireccion);
 router.get('/agents/by-departamento', authenticateToken, getAgentsByDepartamento);
 router.get('/agents/by-division', authenticateToken, getAgentsByDivision);
+
+// Nuevos endpoints para antigüedad, estudios y certificaciones
+router.get('/agents/seniority', authenticateToken, getAgentsBySeniority);
+router.get('/agents/secondary-studies', authenticateToken, getAgentsBySecondaryStudies);
+router.get('/agents/tertiary-studies', authenticateToken, getAgentsByTertiaryStudies);
+router.get('/agents/university-studies', authenticateToken, getAgentsByUniversityStudies);
+router.get('/agents/top-secretarias-university', authenticateToken, getTopSecretariasByUniversity);
+router.get('/agents/top-secretarias-tertiary', authenticateToken, getTopSecretariasByTertiary);
+router.get('/certifications/registration-type', authenticateToken, getAgentsByRegistrationType);
+router.get('/certifications/entry-time', authenticateToken, getAgentsByEntryTime);
+router.get('/certifications/exit-time', authenticateToken, getAgentsByExitTime);
+router.get('/certifications/top-units', authenticateToken, getTopRegistrationUnits);
 
 // Rutas para Neikes y Beca
 router.get('/agents/by-function-neike-beca', authenticateToken, require('../controllers/analyticsController').getAgentsByFunctionNeikeBeca);

--- a/frontend/src/page/DashboardNeikeBeca.jsx
+++ b/frontend/src/page/DashboardNeikeBeca.jsx
@@ -7,6 +7,8 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import AnalyticsIcon from '@mui/icons-material/Analytics';
 import BusinessIcon from '@mui/icons-material/Business';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
+import SchoolIcon from '@mui/icons-material/School';
+import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import StatCard from '../components/StatCard';
 import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
@@ -43,6 +45,17 @@ const DashboardNeikeBeca = () => {
     const [agentsByDepartamento, setAgentsByDepartamento] = useState([]);
     const [agentsByDivision, setAgentsByDivision] = useState([]);
 
+    const [seniorityData, setSeniorityData] = useState([]);
+    const [secondaryData, setSecondaryData] = useState(null);
+    const [tertiaryData, setTertiaryData] = useState(null);
+    const [universityData, setUniversityData] = useState(null);
+    const [topUniSecretariasData, setTopUniSecretariasData] = useState([]);
+    const [topTerSecretariasData, setTopTerSecretariasData] = useState([]);
+
+    const [registrationTypeData, setRegistrationTypeData] = useState([]);
+    const [entryTimeData, setEntryTimeData] = useState([]);
+    const [exitTimeData, setExitTimeData] = useState([]);
+    const [topUnitsData, setTopUnitsData] = useState([]);
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -103,9 +116,9 @@ const DashboardNeikeBeca = () => {
             };
 
             // Ajustar nombres de plantillas a los mismos usados en el backend.
-            // Este dashboard debe consultar únicamente los datos cargados
-            // con la plantilla "Rama completa - Neikes y Beca".
             const TEMPLATE_NEIKES_BECAS = 'Rama completa - Neikes y Beca';
+            const TEMPLATE_DATOS_NEIKES = 'Datos concurso - Neikes y Beca';
+            const TEMPLATE_CONTROL_NEIKES = 'Control de certificaciones - Neikes y Becas';
             const [
                 totalData,
                 ageDistData,
@@ -118,7 +131,17 @@ const DashboardNeikeBeca = () => {
                 direccionGeneralData,
                 direccionData,
                 departamentoData,
-                divisionData
+                divisionData,
+                seniorityRes,
+                secondaryRes,
+                tertiaryRes,
+                universityRes,
+                topUniRes,
+                topTerRes,
+                regTypeRes,
+                entryTimeRes,
+                exitTimeRes,
+                topUnitsRes
             ] = await Promise.all([
                 // Datos correspondientes a la plantilla "Rama completa - Neikes y Beca"
                 safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_NEIKES_BECAS),
@@ -132,7 +155,19 @@ const DashboardNeikeBeca = () => {
                 safeGet(funcs.agentsByDireccionGeneral, [], TEMPLATE_NEIKES_BECAS),
                 safeGet(funcs.agentsByDireccion, [], TEMPLATE_NEIKES_BECAS),
                 safeGet(funcs.agentsByDepartamento, [], TEMPLATE_NEIKES_BECAS),
-                safeGet(funcs.agentsByDivision, [], TEMPLATE_NEIKES_BECAS)
+                safeGet(funcs.agentsByDivision, [], TEMPLATE_NEIKES_BECAS),
+                // Datos para antigüedad y estudios
+                safeGet(funcs.agentsBySeniority, [], TEMPLATE_DATOS_NEIKES),
+                safeGet(funcs.agentsBySecondaryStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_NEIKES),
+                safeGet(funcs.agentsByTertiaryStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_NEIKES),
+                safeGet(funcs.agentsByUniversityStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_NEIKES),
+                safeGet(funcs.agentsByTopSecretariasUniversity, [], TEMPLATE_DATOS_NEIKES),
+                safeGet(funcs.agentsByTopSecretariasTertiary, [], TEMPLATE_DATOS_NEIKES),
+                // Datos para control de certificaciones
+                safeGet(funcs.certificationsRegistrationType, [], TEMPLATE_CONTROL_NEIKES),
+                safeGet(funcs.certificationsEntryTime, [], TEMPLATE_CONTROL_NEIKES),
+                safeGet(funcs.certificationsExitTime, [], TEMPLATE_CONTROL_NEIKES),
+                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_NEIKES)
             ]);
 
             setTotalAgents(totalData.total);
@@ -147,6 +182,16 @@ const DashboardNeikeBeca = () => {
             setAgentsByDireccion(direccionData);
             setAgentsByDepartamento(departamentoData);
             setAgentsByDivision(divisionData);
+            setSeniorityData(seniorityRes);
+            setSecondaryData(secondaryRes);
+            setTertiaryData(tertiaryRes);
+            setUniversityData(universityRes);
+            setTopUniSecretariasData(topUniRes);
+            setTopTerSecretariasData(topTerRes);
+            setRegistrationTypeData(regTypeRes);
+            setEntryTimeData(entryTimeRes);
+            setExitTimeData(exitTimeRes);
+            setTopUnitsData(topUnitsRes);
 
         } catch (err) {
             setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
@@ -279,6 +324,20 @@ const DashboardNeikeBeca = () => {
                     sx={getTabButtonStyles(2)}
                 >
                     Distribución Organizacional
+                </Button>
+                <Button
+                    onClick={() => setTabValue(3)}
+                    startIcon={<SchoolIcon />}
+                    sx={getTabButtonStyles(3)}
+                >
+                    Antigüedad y Estudios
+                </Button>
+                <Button
+                    onClick={() => setTabValue(4)}
+                    startIcon={<AssignmentTurnedInIcon />}
+                    sx={getTabButtonStyles(4)}
+                >
+                    Control de certificaciones – Neikes y Becas
                 </Button>
             </Box>
 
@@ -479,16 +538,142 @@ const DashboardNeikeBeca = () => {
                         />
                     </Grid>
                     <Grid item xs={12} lg={6}>
-                        <CustomDonutChart
-                            data={filterValidData(agentsByDivision, 'division').slice(0, 8)}
-                            title="Agentes por División (Top 8) - Neikes y Beca"
-                            isDarkMode={isDarkMode}
-                            dataKey="count"
-                            nameKey="division"
-                        />
-                    </Grid>
+                    <CustomDonutChart
+                        data={filterValidData(agentsByDivision, 'division').slice(0, 8)}
+                        title="Agentes por División (Top 8) - Neikes y Beca"
+                        isDarkMode={isDarkMode}
+                        dataKey="count"
+                        nameKey="division"
+                    />
                 </Grid>
-            )}
+            </Grid>
+        )}
+
+        {/* Tab 3: Antigüedad y Estudios */}
+        {tabValue === 3 && (
+            <Grid container spacing={3}>
+                <Grid item xs={12}>
+                    <Typography variant="h5" sx={{ mb: 3, fontWeight: 600 }}>
+                        Antigüedad y Estudios
+                    </Typography>
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <CustomBarChart
+                        data={seniorityData}
+                        xKey="range"
+                        barKey="count"
+                        title="Cantidad de agentes según antigüedad municipal"
+                        isDarkMode={isDarkMode}
+                        height={400}
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <CustomDonutChart
+                        data={[
+                            { category: 'Con título secundario', count: secondaryData?.conTitulo || 0 },
+                            { category: 'Otros', count: secondaryData?.otros || 0 }
+                        ]}
+                        title="Agentes según estudios secundarios"
+                        isDarkMode={isDarkMode}
+                        dataKey="count"
+                        nameKey="category"
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <CustomDonutChart
+                        data={[
+                            { category: 'Con título terciario', count: tertiaryData?.conTitulo || 0 },
+                            { category: 'Otros', count: tertiaryData?.otros || 0 }
+                        ]}
+                        title="Agentes según estudios terciarios"
+                        isDarkMode={isDarkMode}
+                        dataKey="count"
+                        nameKey="category"
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <CustomDonutChart
+                        data={[
+                            { category: 'Con título universitario', count: universityData?.conTitulo || 0 },
+                            { category: 'Otros', count: universityData?.otros || 0 }
+                        ]}
+                        title="Agentes según estudios universitarios"
+                        isDarkMode={isDarkMode}
+                        dataKey="count"
+                        nameKey="category"
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <CustomBarChart
+                        data={topUniSecretariasData}
+                        xKey="secretaria"
+                        barKey="count"
+                        title="Top 10 secretarías con más agentes con título universitario"
+                        isDarkMode={isDarkMode}
+                        height={400}
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <CustomBarChart
+                        data={topTerSecretariasData}
+                        xKey="secretaria"
+                        barKey="count"
+                        title="Top 10 secretarías con más agentes con título terciario"
+                        isDarkMode={isDarkMode}
+                        height={400}
+                    />
+                </Grid>
+            </Grid>
+        )}
+
+        {/* Tab 4: Control de certificaciones */}
+        {tabValue === 4 && (
+            <Grid container spacing={3}>
+                <Grid item xs={12}>
+                    <Typography variant="h5" sx={{ mb: 3, fontWeight: 600 }}>
+                        Control de certificaciones – Neikes y Becas
+                    </Typography>
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <CustomBarChart
+                        data={registrationTypeData}
+                        xKey="tipo"
+                        barKey="count"
+                        title="Cantidad de agentes según tipo de registración"
+                        isDarkMode={isDarkMode}
+                        height={400}
+                    />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                    <CustomDonutChart
+                        data={entryTimeData}
+                        title="Agentes según horario de entrada"
+                        isDarkMode={isDarkMode}
+                        dataKey="count"
+                        nameKey="time"
+                    />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                    <CustomDonutChart
+                        data={exitTimeData}
+                        title="Agentes según horario de salida"
+                        isDarkMode={isDarkMode}
+                        dataKey="count"
+                        nameKey="time"
+                    />
+                </Grid>
+                <Grid item xs={12}>
+                    <CustomBarChart
+                        data={topUnitsData}
+                        xKey="unidad"
+                        barKey="count"
+                        title="Top 10 unidades de registración con más agentes"
+                        isDarkMode={isDarkMode}
+                        height={400}
+                    />
+                </Grid>
+            </Grid>
+        )}
 
             {user?.role === 'admin' && (
                 <>

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -7,6 +7,8 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import AnalyticsIcon from '@mui/icons-material/Analytics';
 import BusinessIcon from '@mui/icons-material/Business';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
+import SchoolIcon from '@mui/icons-material/School';
+import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import StatCard from '../components/StatCard';
 import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
@@ -44,6 +46,18 @@ const DashboardPage = () => {
     const [agentsByDireccion, setAgentsByDireccion] = useState([]);
     const [agentsByDepartamento, setAgentsByDepartamento] = useState([]);
     const [agentsByDivision, setAgentsByDivision] = useState([]);
+
+    const [seniorityData, setSeniorityData] = useState([]);
+    const [secondaryData, setSecondaryData] = useState(null);
+    const [tertiaryData, setTertiaryData] = useState(null);
+    const [universityData, setUniversityData] = useState(null);
+    const [topUniSecretariasData, setTopUniSecretariasData] = useState([]);
+    const [topTerSecretariasData, setTopTerSecretariasData] = useState([]);
+
+    const [registrationTypeData, setRegistrationTypeData] = useState([]);
+    const [entryTimeData, setEntryTimeData] = useState([]);
+    const [exitTimeData, setExitTimeData] = useState([]);
+    const [topUnitsData, setTopUnitsData] = useState([]);
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -104,9 +118,9 @@ const DashboardPage = () => {
             };
 
             // Ajustar nombres de plantillas a los mismos usados en el backend.
-            // Este dashboard debe consultar únicamente los datos cargados
-            // con la plantilla "Rama completa - Planta y Contratos".
             const TEMPLATE_PLANTA_CONTRATOS = 'Rama completa - Planta y Contratos';
+            const TEMPLATE_DATOS_CONCURSO = 'Datos concurso - Planta y Contratos';
+            const TEMPLATE_CONTROL_PLANTA = 'Control de certificaciones - Planta y Contratos';
             const [
                 totalData,
                 ageDistData,
@@ -119,7 +133,17 @@ const DashboardPage = () => {
                 direccionGeneralData,
                 direccionData,
                 departamentoData,
-                divisionData
+                divisionData,
+                seniorityRes,
+                secondaryRes,
+                tertiaryRes,
+                universityRes,
+                topUniRes,
+                topTerRes,
+                regTypeRes,
+                entryTimeRes,
+                exitTimeRes,
+                topUnitsRes
             ] = await Promise.all([
                 // Datos generales correspondientes a la plantilla "Rama completa - Planta y Contratos"
                 safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_PLANTA_CONTRATOS),
@@ -133,7 +157,19 @@ const DashboardPage = () => {
                 safeGet(funcs.agentsByDireccionGeneral, [], TEMPLATE_PLANTA_CONTRATOS),
                 safeGet(funcs.agentsByDireccion, [], TEMPLATE_PLANTA_CONTRATOS),
                 safeGet(funcs.agentsByDepartamento, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDivision, [], TEMPLATE_PLANTA_CONTRATOS)
+                safeGet(funcs.agentsByDivision, [], TEMPLATE_PLANTA_CONTRATOS),
+                // Datos para antigüedad y estudios
+                safeGet(funcs.agentsBySeniority, [], TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcs.agentsBySecondaryStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcs.agentsByTertiaryStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcs.agentsByUniversityStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcs.agentsByTopSecretariasUniversity, [], TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcs.agentsByTopSecretariasTertiary, [], TEMPLATE_DATOS_CONCURSO),
+                // Datos para control de certificaciones
+                safeGet(funcs.certificationsRegistrationType, [], TEMPLATE_CONTROL_PLANTA),
+                safeGet(funcs.certificationsEntryTime, [], TEMPLATE_CONTROL_PLANTA),
+                safeGet(funcs.certificationsExitTime, [], TEMPLATE_CONTROL_PLANTA),
+                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_PLANTA)
             ]);
 
             setTotalAgents(totalData.total);
@@ -148,6 +184,16 @@ const DashboardPage = () => {
             setAgentsByDireccion(direccionData);
             setAgentsByDepartamento(departamentoData);
             setAgentsByDivision(divisionData);
+            setSeniorityData(seniorityRes);
+            setSecondaryData(secondaryRes);
+            setTertiaryData(tertiaryRes);
+            setUniversityData(universityRes);
+            setTopUniSecretariasData(topUniRes);
+            setTopTerSecretariasData(topTerRes);
+            setRegistrationTypeData(regTypeRes);
+            setEntryTimeData(entryTimeRes);
+            setExitTimeData(exitTimeRes);
+            setTopUnitsData(topUnitsRes);
 
         } catch (err) {
             setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
@@ -298,6 +344,20 @@ const DashboardPage = () => {
                 >
                     Distribución Organizacional
                 </Button>
+                <Button
+                    onClick={() => setTabValue(3)}
+                    startIcon={<SchoolIcon />}
+                    sx={getTabButtonStyles(3)}
+                >
+                    Antigüedad y Estudios
+                </Button>
+                <Button
+                    onClick={() => setTabValue(4)}
+                    startIcon={<AssignmentTurnedInIcon />}
+                    sx={getTabButtonStyles(4)}
+                >
+                    Control de certificaciones – Planta y Contratos
+                </Button>
             </Box>
 
             {/* Tab 0: Resumen General */}
@@ -350,6 +410,132 @@ const DashboardPage = () => {
                             isDarkMode={isDarkMode}
                             dataKey="count"
                             nameKey="type"
+                        />
+                    </Grid>
+                </Grid>
+            )}
+
+            {/* Tab 3: Antigüedad y Estudios */}
+            {tabValue === 3 && (
+                <Grid container spacing={3}>
+                    <Grid item xs={12}>
+                        <Typography variant="h5" sx={{ mb: 3, fontWeight: 600 }}>
+                            Antigüedad y Estudios
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <CustomBarChart
+                            data={seniorityData}
+                            xKey="range"
+                            barKey="count"
+                            title="Cantidad de agentes según antigüedad municipal"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <CustomDonutChart
+                            data={[
+                                { category: 'Con título secundario', count: secondaryData?.conTitulo || 0 },
+                                { category: 'Otros', count: secondaryData?.otros || 0 }
+                            ]}
+                            title="Agentes según estudios secundarios"
+                            isDarkMode={isDarkMode}
+                            dataKey="count"
+                            nameKey="category"
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <CustomDonutChart
+                            data={[
+                                { category: 'Con título terciario', count: tertiaryData?.conTitulo || 0 },
+                                { category: 'Otros', count: tertiaryData?.otros || 0 }
+                            ]}
+                            title="Agentes según estudios terciarios"
+                            isDarkMode={isDarkMode}
+                            dataKey="count"
+                            nameKey="category"
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <CustomDonutChart
+                            data={[
+                                { category: 'Con título universitario', count: universityData?.conTitulo || 0 },
+                                { category: 'Otros', count: universityData?.otros || 0 }
+                            ]}
+                            title="Agentes según estudios universitarios"
+                            isDarkMode={isDarkMode}
+                            dataKey="count"
+                            nameKey="category"
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <CustomBarChart
+                            data={topUniSecretariasData}
+                            xKey="secretaria"
+                            barKey="count"
+                            title="Top 10 secretarías con más agentes con título universitario"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <CustomBarChart
+                            data={topTerSecretariasData}
+                            xKey="secretaria"
+                            barKey="count"
+                            title="Top 10 secretarías con más agentes con título terciario"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    </Grid>
+                </Grid>
+            )}
+
+            {/* Tab 4: Control de certificaciones */}
+            {tabValue === 4 && (
+                <Grid container spacing={3}>
+                    <Grid item xs={12}>
+                        <Typography variant="h5" sx={{ mb: 3, fontWeight: 600 }}>
+                            Control de certificaciones – Planta y Contratos
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <CustomBarChart
+                            data={registrationTypeData}
+                            xKey="tipo"
+                            barKey="count"
+                            title="Cantidad de agentes según tipo de registración"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={3}>
+                        <CustomDonutChart
+                            data={entryTimeData}
+                            title="Agentes según horario de entrada"
+                            isDarkMode={isDarkMode}
+                            dataKey="count"
+                            nameKey="time"
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={3}>
+                        <CustomDonutChart
+                            data={exitTimeData}
+                            title="Agentes según horario de salida"
+                            isDarkMode={isDarkMode}
+                            dataKey="count"
+                            nameKey="time"
+                        />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <CustomBarChart
+                            data={topUnitsData}
+                            xKey="unidad"
+                            barKey="count"
+                            title="Top 10 unidades de registración con más agentes"
+                            isDarkMode={isDarkMode}
+                            height={400}
                         />
                     </Grid>
                 </Grid>


### PR DESCRIPTION
## Summary
- add backend analytics for seniority, education levels and certification controls
- expose new analytics routes and default functions
- extend dashboards with new tabs and charts for seniority, studies, and certification control
- normalize analytics filters to handle accented field variants and column name differences
- ensure function definitions are synced so new analytics endpoints appear in `/functions`

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a87f548b408327a2a5dd10af1d3069