### PR TITLE
feat: add expedientes analytics

### DIFF
--- a/backend/config/defaultFunctions.js
+++ b/backend/config/defaultFunctions.js
@@ -20,5 +20,7 @@ module.exports = [
   { name: 'certificationsRegistrationType', description: 'Agentes por tipo de registración', endpoint: '/analytics/certifications/registration-type' },
   { name: 'certificationsEntryTime', description: 'Agentes por horario de entrada', endpoint: '/analytics/certifications/entry-time' },
   { name: 'certificationsExitTime', description: 'Agentes por horario de salida', endpoint: '/analytics/certifications/exit-time' },
-  { name: 'certificationsTopUnits', description: 'Top unidades de registración', endpoint: '/analytics/certifications/top-units' }
+  { name: 'certificationsTopUnits', description: 'Top unidades de registración', endpoint: '/analytics/certifications/top-units' },
+  { name: 'expedientesTopInitiators', description: 'Top iniciadores de expedientes', endpoint: '/analytics/expedientes/top-initiators' },
+  { name: 'expedientesByTramite', description: 'Expedientes por tipo de trámite', endpoint: '/analytics/expedientes/by-tramite' }
 ];

--- a/backend/controllers/expedientesController.js
+++ b/backend/controllers/expedientesController.js
@@ -1,0 +1,100 @@
+const Agent = require('../models/Agent');
+
+function computePreviousMonthRange() {
+  const now = new Date();
+  const firstDayOfCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const lastDayOfPreviousMonth = new Date(firstDayOfCurrentMonth - 1);
+  const startDate = new Date(
+    lastDayOfPreviousMonth.getFullYear(),
+    lastDayOfPreviousMonth.getMonth(),
+    1
+  );
+  const endDate = new Date(
+    lastDayOfPreviousMonth.getFullYear(),
+    lastDayOfPreviousMonth.getMonth(),
+    lastDayOfPreviousMonth.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  return { startDate, endDate };
+}
+
+function buildMatch(query) {
+  const plantilla = (query.plantilla || 'Expedientes').trim();
+  const match = { plantilla };
+
+  if (query.filters) {
+    try {
+      const extra = JSON.parse(query.filters);
+      Object.assign(match, extra);
+    } catch (e) {
+      console.error('Error parsing filters:', e);
+    }
+  }
+
+  const andFilters = [];
+  const addRegexFilter = (fields, value) => {
+    if (!value) return;
+    const orConditions = fields.map(f => ({ [f]: { $regex: value, $options: 'i' } }));
+    andFilters.push({ $or: orConditions });
+  };
+
+  addRegexFilter(['Secretaria', 'Secretaría'], query.secretaria);
+  addRegexFilter(['Subsecretaria', 'Subsecretaría'], query.subsecretaria);
+  addRegexFilter(['Dirección general', 'Direccion General', 'Dirección General'], query.direccionGeneral);
+  addRegexFilter(['Dirección', 'Direccion'], query.direccion);
+  addRegexFilter(['Departamento'], query.departamento);
+  addRegexFilter(['División', 'Division'], query.division);
+  addRegexFilter(['Funcion', 'Función'], query.funcion);
+
+  if (andFilters.length) {
+    match.$and = andFilters;
+  }
+
+  return match;
+}
+
+const getTopInitiators = async (req, res) => {
+  try {
+    const { startDate, endDate } = computePreviousMonthRange();
+    const match = buildMatch(req.query);
+    match['Fecha de Inicio'] = { $gte: startDate, $lte: endDate };
+
+    const topInitiators = await Agent.aggregate([
+      { $match: match },
+      { $group: { _id: '$Iniciador del Expediente', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 10 },
+      { $project: { initiator: '$_id', count: 1, _id: 0 } }
+    ]);
+
+    res.json(topInitiators);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Error al obtener iniciadores' });
+  }
+};
+
+const getExpedientesByTramite = async (req, res) => {
+  try {
+    const { startDate, endDate } = computePreviousMonthRange();
+    const match = buildMatch(req.query);
+    match['Fecha de Inicio'] = { $gte: startDate, $lte: endDate };
+
+    const byTramite = await Agent.aggregate([
+      { $match: match },
+      { $group: { _id: '$Tramite', count: { $sum: 1 } } },
+      { $project: { tramite: '$_id', count: 1, _id: 0 } }
+    ]);
+
+    res.json(byTramite);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Error al obtener expedientes por tipo de trámite' });
+  }
+};
+
+module.exports = { getTopInitiators, getExpedientesByTramite };
+

--- a/backend/routes/expedientes.js
+++ b/backend/routes/expedientes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { authenticateToken } = require('../middleware/authMiddleware');
+const expedientesController = require('../controllers/expedientesController');
+
+router.get('/expedientes/top-initiators', authenticateToken, expedientesController.getTopInitiators);
+router.get('/expedientes/by-tramite', authenticateToken, expedientesController.getExpedientesByTramite);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,7 @@ const connectDB = require('./config/db'); // Importar la función centralizada
 const authRoutes = require('./routes/auth');
 const uploadRoutes = require('./routes/uploadRoutes');
 const analyticsRoutes = require('./routes/analytics');
+const expedientesRoutes = require('./routes/expedientes');
 const dependencyRoutes = require('./routes/dependency');
 const notificationRoutes = require('./routes/notifications');
 const variableRoutes = require('./routes/variables');
@@ -37,6 +38,7 @@ connectDB().then(initFunctions);
 app.use('/api/auth', authRoutes);
 app.use('/api/upload', uploadRoutes);
 app.use('/api/analytics', analyticsRoutes);
+app.use('/api/analytics', expedientesRoutes);
 app.use('/api/dependencies', dependencyRoutes);
 app.use('/api/notifications', notificationRoutes);
 app.use('/api/variables', variableRoutes);

--- a/frontend/src/page/DashboardNeikeBeca.jsx
+++ b/frontend/src/page/DashboardNeikeBeca.jsx
@@ -9,6 +9,7 @@ import BusinessIcon from '@mui/icons-material/Business';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import SchoolIcon from '@mui/icons-material/School';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import StatCard from '../components/StatCard';
 import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
@@ -56,6 +57,8 @@ const DashboardNeikeBeca = () => {
     const [entryTimeData, setEntryTimeData] = useState([]);
     const [exitTimeData, setExitTimeData] = useState([]);
     const [topUnitsData, setTopUnitsData] = useState([]);
+    const [expTopInitiators, setExpTopInitiators] = useState([]);
+    const [expByTramite, setExpByTramite] = useState([]);
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -119,6 +122,7 @@ const DashboardNeikeBeca = () => {
             const TEMPLATE_NEIKES_BECAS = 'Rama completa - Neikes y Beca';
             const TEMPLATE_DATOS_NEIKES = 'Datos concurso - Neikes y Beca';
             const TEMPLATE_CONTROL_NEIKES = 'Control de certificaciones - Neikes y Becas';
+            const TEMPLATE_EXPEDIENTES = 'Expedientes';
             const [
                 totalData,
                 ageDistData,
@@ -141,7 +145,9 @@ const DashboardNeikeBeca = () => {
                 regTypeRes,
                 entryTimeRes,
                 exitTimeRes,
-                topUnitsRes
+                topUnitsRes,
+                topInitiatorsData,
+                byTramiteData
             ] = await Promise.all([
                 // Datos correspondientes a la plantilla "Rama completa - Neikes y Beca"
                 safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_NEIKES_BECAS),
@@ -167,7 +173,9 @@ const DashboardNeikeBeca = () => {
                 safeGet(funcs.certificationsRegistrationType, [], TEMPLATE_CONTROL_NEIKES),
                 safeGet(funcs.certificationsEntryTime, [], TEMPLATE_CONTROL_NEIKES),
                 safeGet(funcs.certificationsExitTime, [], TEMPLATE_CONTROL_NEIKES),
-                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_NEIKES)
+                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_NEIKES),
+                safeGet(funcs.expedientesTopInitiators, [], TEMPLATE_EXPEDIENTES),
+                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES)
             ]);
 
             setTotalAgents(totalData.total);
@@ -192,6 +200,8 @@ const DashboardNeikeBeca = () => {
             setEntryTimeData(entryTimeRes);
             setExitTimeData(exitTimeRes);
             setTopUnitsData(topUnitsRes);
+            setExpTopInitiators(topInitiatorsData);
+            setExpByTramite(byTramiteData);
 
         } catch (err) {
             setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
@@ -248,6 +258,24 @@ const DashboardNeikeBeca = () => {
                 : '0 6px 20px rgba(33, 150, 243, 0.2)',
         },
     });
+
+    const getPreviousMonthRange = () => {
+        const now = new Date();
+        const firstDayCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+        const lastDayPreviousMonth = new Date(firstDayCurrentMonth - 1);
+        const firstDayPreviousMonth = new Date(
+            lastDayPreviousMonth.getFullYear(),
+            lastDayPreviousMonth.getMonth(),
+            1
+        );
+        const format = (d) => d.toLocaleDateString('es-AR');
+        return {
+            start: format(firstDayPreviousMonth),
+            end: format(lastDayPreviousMonth)
+        };
+    };
+
+    const { start, end } = getPreviousMonthRange();
 
     if (loading) {
         return (
@@ -338,6 +366,13 @@ const DashboardNeikeBeca = () => {
                     sx={getTabButtonStyles(4)}
                 >
                     Control de certificaciones – Neikes y Becas
+                </Button>
+                <Button
+                    onClick={() => setTabValue(5)}
+                    startIcon={<FolderOpenIcon />}
+                    sx={getTabButtonStyles(5)}
+                >
+                    Expedientes
                 </Button>
             </Box>
 
@@ -671,6 +706,44 @@ const DashboardNeikeBeca = () => {
                         isDarkMode={isDarkMode}
                         height={400}
                     />
+                </Grid>
+            </Grid>
+        )}
+
+        {/* Tab 5: Expedientes */}
+        {tabValue === 5 && (
+            <Grid container spacing={3}>
+                <Grid item xs={12}>
+                    <Typography variant="subtitle2" color="text.secondary">
+                        Expedientes a mes vencido. Corte del {start} al {end}.
+                    </Typography>
+                </Grid>
+                <Grid item xs={12}>
+                    {expTopInitiators.length > 0 ? (
+                        <CustomBarChart
+                            data={expTopInitiators}
+                            xKey="initiator"
+                            barKey="count"
+                            title="Top 10 áreas con más trámites gestionados"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    ) : (
+                        <Typography>Sin datos</Typography>
+                    )}
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    {expByTramite.length > 0 ? (
+                        <CustomDonutChart
+                            data={expByTramite}
+                            title="Cantidad de expedientes según tipo de trámite"
+                            isDarkMode={isDarkMode}
+                            dataKey="count"
+                            nameKey="tramite"
+                        />
+                    ) : (
+                        <Typography>Sin datos</Typography>
+                    )}
                 </Grid>
             </Grid>
         )}

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -9,6 +9,7 @@ import BusinessIcon from '@mui/icons-material/Business';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import SchoolIcon from '@mui/icons-material/School';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import StatCard from '../components/StatCard';
 import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
@@ -58,6 +59,8 @@ const DashboardPage = () => {
     const [entryTimeData, setEntryTimeData] = useState([]);
     const [exitTimeData, setExitTimeData] = useState([]);
     const [topUnitsData, setTopUnitsData] = useState([]);
+    const [expTopInitiators, setExpTopInitiators] = useState([]);
+    const [expByTramite, setExpByTramite] = useState([]);
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -121,6 +124,7 @@ const DashboardPage = () => {
             const TEMPLATE_PLANTA_CONTRATOS = 'Rama completa - Planta y Contratos';
             const TEMPLATE_DATOS_CONCURSO = 'Datos concurso - Planta y Contratos';
             const TEMPLATE_CONTROL_PLANTA = 'Control de certificaciones - Planta y Contratos';
+            const TEMPLATE_EXPEDIENTES = 'Expedientes';
             const [
                 totalData,
                 ageDistData,
@@ -143,7 +147,9 @@ const DashboardPage = () => {
                 regTypeRes,
                 entryTimeRes,
                 exitTimeRes,
-                topUnitsRes
+                topUnitsRes,
+                topInitiatorsData,
+                byTramiteData
             ] = await Promise.all([
                 // Datos generales correspondientes a la plantilla "Rama completa - Planta y Contratos"
                 safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_PLANTA_CONTRATOS),
@@ -169,7 +175,9 @@ const DashboardPage = () => {
                 safeGet(funcs.certificationsRegistrationType, [], TEMPLATE_CONTROL_PLANTA),
                 safeGet(funcs.certificationsEntryTime, [], TEMPLATE_CONTROL_PLANTA),
                 safeGet(funcs.certificationsExitTime, [], TEMPLATE_CONTROL_PLANTA),
-                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_PLANTA)
+                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_PLANTA),
+                safeGet(funcs.expedientesTopInitiators, [], TEMPLATE_EXPEDIENTES),
+                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES)
             ]);
 
             setTotalAgents(totalData.total);
@@ -194,6 +202,8 @@ const DashboardPage = () => {
             setEntryTimeData(entryTimeRes);
             setExitTimeData(exitTimeRes);
             setTopUnitsData(topUnitsRes);
+            setExpTopInitiators(topInitiatorsData);
+            setExpByTramite(byTramiteData);
 
         } catch (err) {
             setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
@@ -267,6 +277,24 @@ const DashboardPage = () => {
                 : '0 6px 20px rgba(33, 150, 243, 0.2)',
         },
     });
+
+    const getPreviousMonthRange = () => {
+        const now = new Date();
+        const firstDayCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+        const lastDayPreviousMonth = new Date(firstDayCurrentMonth - 1);
+        const firstDayPreviousMonth = new Date(
+            lastDayPreviousMonth.getFullYear(),
+            lastDayPreviousMonth.getMonth(),
+            1
+        );
+        const format = (d) => d.toLocaleDateString('es-AR');
+        return {
+            start: format(firstDayPreviousMonth),
+            end: format(lastDayPreviousMonth)
+        };
+    };
+
+    const { start, end } = getPreviousMonthRange();
 
     if (loading) {
         return (
@@ -357,6 +385,13 @@ const DashboardPage = () => {
                     sx={getTabButtonStyles(4)}
                 >
                     Control de certificaciones – Planta y Contratos
+                </Button>
+                <Button
+                    onClick={() => setTabValue(5)}
+                    startIcon={<FolderOpenIcon />}
+                    sx={getTabButtonStyles(5)}
+                >
+                    Expedientes
                 </Button>
             </Box>
 
@@ -537,6 +572,44 @@ const DashboardPage = () => {
                             isDarkMode={isDarkMode}
                             height={400}
                         />
+                    </Grid>
+                </Grid>
+            )}
+
+            {/* Tab 5: Expedientes */}
+            {tabValue === 5 && (
+                <Grid container spacing={3}>
+                    <Grid item xs={12}>
+                        <Typography variant="subtitle2" color="text.secondary">
+                            Expedientes a mes vencido. Corte del {start} al {end}.
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                        {expTopInitiators.length > 0 ? (
+                            <CustomBarChart
+                                data={expTopInitiators}
+                                xKey="initiator"
+                                barKey="count"
+                                title="Top 10 áreas con más trámites gestionados"
+                                isDarkMode={isDarkMode}
+                                height={400}
+                            />
+                        ) : (
+                            <Typography>Sin datos</Typography>
+                        )}
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        {expByTramite.length > 0 ? (
+                            <CustomDonutChart
+                                data={expByTramite}
+                                title="Cantidad de expedientes según tipo de trámite"
+                                isDarkMode={isDarkMode}
+                                dataKey="count"
+                                nameKey="tramite"
+                            />
+                        ) : (
+                            <Typography>Sin datos</Typography>
+                        )}
                     </Grid>
                 </Grid>
             )}


### PR DESCRIPTION
## Summary
- add controller and routes to analyze expedientes
- expose expedientes endpoints via functions list
- render Expedientes charts and tab in dashboards

## Testing
- `cd backend && npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0719e1988327be6a3d94f800ab9d