### PR TITLE
feat: add expedientes dashboards with bar charts

### DIFF
--- a/backend/config/defaultFunctions.js
+++ b/backend/config/defaultFunctions.js
@@ -20,5 +20,7 @@ module.exports = [
   { name: 'certificationsRegistrationType', description: 'Agentes por tipo de registración', endpoint: '/analytics/certifications/registration-type' },
   { name: 'certificationsEntryTime', description: 'Agentes por horario de entrada', endpoint: '/analytics/certifications/entry-time' },
   { name: 'certificationsExitTime', description: 'Agentes por horario de salida', endpoint: '/analytics/certifications/exit-time' },
-  { name: 'certificationsTopUnits', description: 'Top unidades de registración', endpoint: '/analytics/certifications/top-units' }
+  { name: 'certificationsTopUnits', description: 'Top unidades de registración', endpoint: '/analytics/certifications/top-units' },
+  { name: 'expedientesTopInitiators', description: 'Top iniciadores de expedientes', endpoint: '/analytics/expedientes/top-initiators' },
+  { name: 'expedientesByTramite', description: 'Expedientes por tipo de trámite', endpoint: '/analytics/expedientes/by-tramite' }
 ];

--- a/backend/controllers/expedientesController.js
+++ b/backend/controllers/expedientesController.js
@@ -1,0 +1,72 @@
+const Agent = require('../models/Agent');
+
+function computePreviousMonthRange() {
+  const now = new Date();
+  const firstDayCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const lastDayPreviousMonth = new Date(firstDayCurrentMonth - 1);
+  const startDate = new Date(
+    lastDayPreviousMonth.getFullYear(),
+    lastDayPreviousMonth.getMonth(),
+    1
+  );
+  const endDate = new Date(
+    lastDayPreviousMonth.getFullYear(),
+    lastDayPreviousMonth.getMonth(),
+    lastDayPreviousMonth.getDate(),
+    23,
+    59,
+    59,
+    999
+  );
+  return { startDate, endDate };
+}
+
+const getTopInitiators = async (req, res) => {
+  try {
+    const { plantilla, filters } = req.query;
+    const { startDate, endDate } = computePreviousMonthRange();
+    const match = {
+      plantilla: plantilla || 'Expedientes',
+      'Fecha de Inicio': { $gte: startDate, $lte: endDate },
+      ...(filters && JSON.parse(filters))
+    };
+    const topInitiators = await Agent.aggregate([
+      { $match: match },
+      { $group: { _id: '$Iniciador del Expediente', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 10 },
+      { $project: { initiator: '$_id', count: 1, _id: 0 } }
+    ]);
+    res.json(topInitiators);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Error al obtener iniciadores' });
+  }
+};
+
+const getExpedientesByTramite = async (req, res) => {
+  try {
+    const { plantilla, filters } = req.query;
+    const { startDate, endDate } = computePreviousMonthRange();
+    const match = {
+      plantilla: plantilla || 'Expedientes',
+      'Fecha de Inicio': { $gte: startDate, $lte: endDate },
+      ...(filters && JSON.parse(filters))
+    };
+    const byTramite = await Agent.aggregate([
+      { $match: match },
+      { $group: { _id: '$Tramite', count: { $sum: 1 } } },
+      { $project: { tramite: '$_id', count: 1, _id: 0 } }
+    ]);
+    res.json(byTramite);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Error al obtener expedientes por tipo de trámite' });
+  }
+};
+
+module.exports = {
+  getTopInitiators,
+  getExpedientesByTramite,
+  computePreviousMonthRange
+};

--- a/backend/routes/expedientes.js
+++ b/backend/routes/expedientes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const expedientesController = require('../controllers/expedientesController');
+const { authenticateToken } = require('../middleware/authMiddleware');
+
+router.get('/expedientes/top-initiators', authenticateToken, expedientesController.getTopInitiators);
+router.get('/expedientes/by-tramite', authenticateToken, expedientesController.getExpedientesByTramite);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,7 @@ const connectDB = require('./config/db'); // Importar la función centralizada
 const authRoutes = require('./routes/auth');
 const uploadRoutes = require('./routes/uploadRoutes');
 const analyticsRoutes = require('./routes/analytics');
+const expedientesRoutes = require('./routes/expedientes');
 const dependencyRoutes = require('./routes/dependency');
 const notificationRoutes = require('./routes/notifications');
 const variableRoutes = require('./routes/variables');
@@ -37,6 +38,7 @@ connectDB().then(initFunctions);
 app.use('/api/auth', authRoutes);
 app.use('/api/upload', uploadRoutes);
 app.use('/api/analytics', analyticsRoutes);
+app.use('/api/analytics', expedientesRoutes);
 app.use('/api/dependencies', dependencyRoutes);
 app.use('/api/notifications', notificationRoutes);
 app.use('/api/variables', variableRoutes);

--- a/frontend/src/page/DashboardNeikeBeca.jsx
+++ b/frontend/src/page/DashboardNeikeBeca.jsx
@@ -9,11 +9,13 @@ import BusinessIcon from '@mui/icons-material/Business';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import SchoolIcon from '@mui/icons-material/School';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import StatCard from '../components/StatCard';
 import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
 import CustomAreaChart from '../components/CustomAreaChart';
 import DependencyFilter from '../components/DependencyFilter.jsx';
+import { getPreviousMonthRange } from '../utils/dateUtils';
 
 const DashboardNeikeBeca = () => {
     const { user } = useAuth();
@@ -56,6 +58,9 @@ const DashboardNeikeBeca = () => {
     const [entryTimeData, setEntryTimeData] = useState([]);
     const [exitTimeData, setExitTimeData] = useState([]);
     const [topUnitsData, setTopUnitsData] = useState([]);
+    const [expTopInitiators, setExpTopInitiators] = useState([]);
+    const [expByTramite, setExpByTramite] = useState([]);
+    const { start: expStart, end: expEnd } = getPreviousMonthRange();
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -119,6 +124,7 @@ const DashboardNeikeBeca = () => {
             const TEMPLATE_NEIKES_BECAS = 'Rama completa - Neikes y Beca';
             const TEMPLATE_DATOS_NEIKES = 'Datos concurso - Neikes y Beca';
             const TEMPLATE_CONTROL_NEIKES = 'Control de certificaciones - Neikes y Becas';
+            const TEMPLATE_EXPEDIENTES = 'Expedientes';
             const [
                 totalData,
                 ageDistData,
@@ -141,7 +147,9 @@ const DashboardNeikeBeca = () => {
                 regTypeRes,
                 entryTimeRes,
                 exitTimeRes,
-                topUnitsRes
+                topUnitsRes,
+                topInitiatorsData,
+                byTramiteData
             ] = await Promise.all([
                 // Datos correspondientes a la plantilla "Rama completa - Neikes y Beca"
                 safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_NEIKES_BECAS),
@@ -167,7 +175,10 @@ const DashboardNeikeBeca = () => {
                 safeGet(funcs.certificationsRegistrationType, [], TEMPLATE_CONTROL_NEIKES),
                 safeGet(funcs.certificationsEntryTime, [], TEMPLATE_CONTROL_NEIKES),
                 safeGet(funcs.certificationsExitTime, [], TEMPLATE_CONTROL_NEIKES),
-                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_NEIKES)
+                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_NEIKES),
+                // Expedientes
+                safeGet(funcs.expedientesTopInitiators, [], TEMPLATE_EXPEDIENTES),
+                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES)
             ]);
 
             setTotalAgents(totalData.total);
@@ -192,6 +203,8 @@ const DashboardNeikeBeca = () => {
             setEntryTimeData(entryTimeRes);
             setExitTimeData(exitTimeRes);
             setTopUnitsData(topUnitsRes);
+            setExpTopInitiators(topInitiatorsData);
+            setExpByTramite(byTramiteData);
 
         } catch (err) {
             setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
@@ -338,6 +351,13 @@ const DashboardNeikeBeca = () => {
                     sx={getTabButtonStyles(4)}
                 >
                     Control de certificaciones – Neikes y Becas
+                </Button>
+                <Button
+                    onClick={() => setTabValue(5)}
+                    startIcon={<FolderOpenIcon />}
+                    sx={getTabButtonStyles(5)}
+                >
+                    Expedientes
                 </Button>
             </Box>
 
@@ -671,6 +691,48 @@ const DashboardNeikeBeca = () => {
                         isDarkMode={isDarkMode}
                         height={400}
                     />
+                </Grid>
+            </Grid>
+        )}
+
+        {/* Tab 5: Expedientes */}
+        {tabValue === 5 && (
+            <Grid container spacing={3}>
+                <Grid item xs={12}>
+                    <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
+                        Expedientes
+                    </Typography>
+                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 3 }}>
+                        Expedientes a mes vencido. Corte del {expStart} al {expEnd}.
+                    </Typography>
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    {expTopInitiators.length > 0 ? (
+                        <CustomBarChart
+                            data={expTopInitiators}
+                            xKey="initiator"
+                            barKey="count"
+                            title="Top 10 áreas con más trámites gestionados"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    ) : (
+                        <Typography align="center">Sin datos</Typography>
+                    )}
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    {expByTramite.length > 0 ? (
+                        <CustomBarChart
+                            data={expByTramite}
+                            xKey="tramite"
+                            barKey="count"
+                            title="Cantidad de expedientes según tipo de trámite"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    ) : (
+                        <Typography align="center">Sin datos</Typography>
+                    )}
                 </Grid>
             </Grid>
         )}

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -1,0 +1,15 @@
+export const getPreviousMonthRange = () => {
+    const now = new Date();
+    const firstDayCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    const lastDayPreviousMonth = new Date(firstDayCurrentMonth - 1);
+    const firstDayPreviousMonth = new Date(
+        lastDayPreviousMonth.getFullYear(),
+        lastDayPreviousMonth.getMonth(),
+        1
+    );
+    const format = (d) => d.toLocaleDateString('es-AR');
+    return {
+        start: format(firstDayPreviousMonth),
+        end: format(lastDayPreviousMonth),
+    };
+};


### PR DESCRIPTION
## Summary
- expose Expedientes analytics with previous-month filtering and aggregation endpoints
- wire up routes/functions and add Expedientes tab with bar charts for initiators and trámites
- fix Expedientes routes to use existing auth middleware
- consolidate previous-month range helper to avoid redeclaration in dashboards

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend` *(fails: vitest: not found)*
- `npm run build --prefix frontend` *(fails: tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0719e1988327be6a3d94f800ab9d