### PR TITLE
Add SAC analytics endpoint and dashboard section

### DIFF
--- a/backend/config/defaultFunctions.js
+++ b/backend/config/defaultFunctions.js
@@ -22,5 +22,6 @@ module.exports = [
   { name: 'certificationsExitTime', description: 'Agentes por horario de salida', endpoint: '/analytics/certifications/exit-time' },
   { name: 'certificationsTopUnits', description: 'Top unidades de registración', endpoint: '/analytics/certifications/top-units' },
   { name: 'expedientesTopInitiators', description: 'Top iniciadores de expedientes', endpoint: '/analytics/expedientes/top-initiators' },
-  { name: 'expedientesByTramite', description: 'Expedientes por tipo de trámite', endpoint: '/analytics/expedientes/by-tramite' }
+  { name: 'expedientesByTramite', description: 'Expedientes por tipo de trámite', endpoint: '/analytics/expedientes/by-tramite' },
+  { name: 'sacViaCaptacion', description: 'SAC vía de captación', endpoint: '/analytics/sac/via-captacion' }
 ];

--- a/backend/controllers/uploadController.js
+++ b/backend/controllers/uploadController.js
@@ -105,10 +105,12 @@ async function uploadFile(req, res) {
         // Primer fila: encabezado real
         const encabezado = datos[0].map(cell => String(cell).trim());
         // Mapear los datos según el mapping de la plantilla, solo si la fila es válida
-        let camposClave = [];
-        // Definir campos clave dinámicos según la plantilla
-        if (template.name && template.name.trim().toLowerCase() === 'expedientes') {
-          camposClave = ['Numero de expediente', 'Iniciador del Expediente', 'CUIT'];
+        let camposClave;
+        const templateName = template.name ? template.name.trim().toLowerCase() : '';
+        if (templateName.includes('via de captacion') || templateName.includes('sac')) {
+          camposClave = ['Via', 'Total'];
+        } else if (templateName.includes('expedientes')) {
+          camposClave = ['Numero de expediente', 'Iniciador del Expediente'];
         } else {
           camposClave = ['dni', 'legajo', 'nombre', 'DNI', 'Legajo', 'Nombre', 'Nombre y Apellido'];
         }

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -43,7 +43,8 @@ const {
   getAgentsByEntryTime,
   getAgentsByExitTime,
   getTopRegistrationUnits,
-  notifyDashboardModification
+  notifyDashboardModification,
+  getSacViaCaptacion
 } = require('../controllers/analyticsController');
 
 router.get('/secretarias', authenticateToken, getSecretarias);
@@ -80,6 +81,9 @@ router.get('/certifications/registration-type', authenticateToken, getAgentsByRe
 router.get('/certifications/entry-time', authenticateToken, getAgentsByEntryTime);
 router.get('/certifications/exit-time', authenticateToken, getAgentsByExitTime);
 router.get('/certifications/top-units', authenticateToken, getTopRegistrationUnits);
+
+// Rutas para SAC
+router.get('/sac/via-captacion', authenticateToken, getSacViaCaptacion);
 
 // Rutas para Neikes y Beca
 router.get('/agents/by-function-neike-beca', authenticateToken, require('../controllers/analyticsController').getAgentsByFunctionNeikeBeca);

--- a/backend/utils/dateUtils.js
+++ b/backend/utils/dateUtils.js
@@ -1,0 +1,15 @@
+function getPreviousMonthRange() {
+  const now = new Date();
+  const firstDayCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const lastDayPreviousMonth = new Date(firstDayCurrentMonth - 1);
+  const firstDayPreviousMonth = new Date(
+    lastDayPreviousMonth.getFullYear(),
+    lastDayPreviousMonth.getMonth(),
+    1
+  );
+  const startDate = firstDayPreviousMonth.toISOString().split('T')[0];
+  const endDate = lastDayPreviousMonth.toISOString().split('T')[0];
+  return { startDate, endDate };
+}
+
+module.exports = { getPreviousMonthRange };

--- a/frontend/src/components/MonthCutoffAlert.jsx
+++ b/frontend/src/components/MonthCutoffAlert.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Alert, Box, Typography } from '@mui/material';
+
+const MonthCutoffAlert = ({ systemName, startDate, endDate }) => (
+    <Box my={2}>
+        <Alert
+            severity="info"
+            icon={false}
+            sx={{ bgcolor: 'rgba(33,150,243,0.1)', borderLeft: '6px solid #2196f3' }}
+        >
+            <Typography variant="body2" fontWeight={600}>
+                {`Datos tomados del sistema ${systemName} con corte del ${startDate} al ${endDate}.`}
+            </Typography>
+        </Alert>
+    </Box>
+);
+
+export default MonthCutoffAlert;

--- a/frontend/src/page/DashboardNeikeBeca.jsx
+++ b/frontend/src/page/DashboardNeikeBeca.jsx
@@ -10,12 +10,14 @@ import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import SchoolIcon from '@mui/icons-material/School';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
+import PhoneIcon from '@mui/icons-material/Phone';
 import StatCard from '../components/StatCard';
 import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
 import CustomAreaChart from '../components/CustomAreaChart';
 import DependencyFilter from '../components/DependencyFilter.jsx';
 import { getPreviousMonthRange } from '../utils/dateUtils';
+import MonthCutoffAlert from '../components/MonthCutoffAlert';
 
 const DashboardNeikeBeca = () => {
     const { user } = useAuth();
@@ -60,7 +62,10 @@ const DashboardNeikeBeca = () => {
     const [topUnitsData, setTopUnitsData] = useState([]);
     const [expTopInitiators, setExpTopInitiators] = useState([]);
     const [expByTramite, setExpByTramite] = useState([]);
-    const { start: expStart, end: expEnd } = getPreviousMonthRange();
+    const [sacViaData, setSacViaData] = useState([]);
+    const { startDate, endDate } = getPreviousMonthRange();
+    const startDateFormatted = new Date(startDate).toLocaleDateString('es-AR');
+    const endDateFormatted = new Date(endDate).toLocaleDateString('es-AR');
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -104,7 +109,7 @@ const DashboardNeikeBeca = () => {
             // Obtiene datos de forma segura: si falta el endpoint o la petición falla,
             // devuelve el valor por defecto. En caso contrario, retorna solo el campo
             // `data` de la respuesta.
-            const safeGet = async (endpoint, defaultData, plantilla) => {
+            const safeGet = async (endpoint, defaultData, plantilla, extraParams = {}) => {
                 if (!endpoint) return defaultData;
                 const params = Object.fromEntries(
                     Object.entries(appliedFilters).filter(([, v]) => v)
@@ -112,6 +117,7 @@ const DashboardNeikeBeca = () => {
                 if (plantilla) {
                     params.plantilla = plantilla;
                 }
+                Object.assign(params, extraParams);
                 try {
                     const res = await apiClient.get(endpoint, { params });
                     return res.data;
@@ -125,6 +131,7 @@ const DashboardNeikeBeca = () => {
             const TEMPLATE_DATOS_NEIKES = 'Datos concurso - Neikes y Beca';
             const TEMPLATE_CONTROL_NEIKES = 'Control de certificaciones - Neikes y Becas';
             const TEMPLATE_EXPEDIENTES = 'Expedientes';
+            const TEMPLATE_SAC_VIAS = 'SAC - Via de captacion';
             const [
                 totalData,
                 ageDistData,
@@ -149,7 +156,8 @@ const DashboardNeikeBeca = () => {
                 exitTimeRes,
                 topUnitsRes,
                 topInitiatorsData,
-                byTramiteData
+                byTramiteData,
+                sacViaCaptacionData
             ] = await Promise.all([
                 // Datos correspondientes a la plantilla "Rama completa - Neikes y Beca"
                 safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_NEIKES_BECAS),
@@ -178,7 +186,9 @@ const DashboardNeikeBeca = () => {
                 safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_NEIKES),
                 // Expedientes
                 safeGet(funcs.expedientesTopInitiators, [], TEMPLATE_EXPEDIENTES),
-                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES)
+                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES),
+                // SAC
+                safeGet(funcs.sacViaCaptacion, [], TEMPLATE_SAC_VIAS, { startDate, endDate })
             ]);
 
             setTotalAgents(totalData.total);
@@ -205,6 +215,7 @@ const DashboardNeikeBeca = () => {
             setTopUnitsData(topUnitsRes);
             setExpTopInitiators(topInitiatorsData);
             setExpByTramite(byTramiteData);
+            setSacViaData(sacViaCaptacionData);
 
         } catch (err) {
             setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
@@ -261,8 +272,6 @@ const DashboardNeikeBeca = () => {
                 : '0 6px 20px rgba(33, 150, 243, 0.2)',
         },
     });
-
-    const { start, end } = getPreviousMonthRange();
 
     if (loading) {
         return (
@@ -360,6 +369,13 @@ const DashboardNeikeBeca = () => {
                     sx={getTabButtonStyles(5)}
                 >
                     Expedientes
+                </Button>
+                <Button
+                    onClick={() => setTabValue(6)}
+                    startIcon={<PhoneIcon />}
+                    sx={getTabButtonStyles(6)}
+                >
+                    SAC
                 </Button>
             </Box>
 
@@ -701,11 +717,9 @@ const DashboardNeikeBeca = () => {
         {tabValue === 5 && (
             <Grid container spacing={3}>
                 <Grid item xs={12}>
+                    <MonthCutoffAlert systemName="de expedientes" startDate={startDateFormatted} endDate={endDateFormatted} />
                     <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
                         Expedientes
-                    </Typography>
-                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 3 }}>
-                        Expedientes a mes vencido. Corte del {expStart} al {expEnd}.
                     </Typography>
                 </Grid>
                 <Grid item xs={12} md={6}>
@@ -739,9 +753,35 @@ const DashboardNeikeBeca = () => {
             </Grid>
         )}
 
-            {user?.role === 'admin' && (
-                <>
-                    <Tooltip title={cleaning ? 'Limpiando...' : 'Limpiar Dashboard'}>
+        {/* Tab 6: SAC */}
+        {tabValue === 6 && (
+            <Grid container spacing={3}>
+                <Grid item xs={12}>
+                    <MonthCutoffAlert systemName="SAC" startDate={startDateFormatted} endDate={endDateFormatted} />
+                    <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
+                        SAC
+                    </Typography>
+                </Grid>
+                <Grid item xs={12}>
+                    {sacViaData.length > 0 ? (
+                        <CustomBarChart
+                            data={sacViaData}
+                            xKey="via"
+                            barKey="total"
+                            title="Análisis de vía de captación"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    ) : (
+                        <Typography align="center">Sin datos</Typography>
+                    )}
+                </Grid>
+            </Grid>
+        )}
+
+        {user?.role === 'admin' && (
+            <>
+                <Tooltip title={cleaning ? 'Limpiando...' : 'Limpiar Dashboard'}>
                         <Fab
                             onClick={handleLimpiarDashboard}
                             disabled={cleaning}

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -10,6 +10,7 @@ import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import SchoolIcon from '@mui/icons-material/School';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
+import PhoneIcon from '@mui/icons-material/Phone';
 import StatCard from '../components/StatCard';
 import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
@@ -17,6 +18,7 @@ import CustomAreaChart from '../components/CustomAreaChart';
 import DependencyFilter from '../components/DependencyFilter.jsx';
 import { useLocation } from 'react-router-dom';
 import { getPreviousMonthRange } from '../utils/dateUtils';
+import MonthCutoffAlert from '../components/MonthCutoffAlert'; // shared alert component
 
 const DashboardPage = () => {
     const { user } = useAuth();
@@ -62,7 +64,10 @@ const DashboardPage = () => {
     const [topUnitsData, setTopUnitsData] = useState([]);
     const [expTopInitiators, setExpTopInitiators] = useState([]);
     const [expByTramite, setExpByTramite] = useState([]);
-    const { start: expStart, end: expEnd } = getPreviousMonthRange();
+    const [sacViaData, setSacViaData] = useState([]);
+    const { startDate, endDate } = getPreviousMonthRange();
+    const startDateFormatted = new Date(startDate).toLocaleDateString('es-AR');
+    const endDateFormatted = new Date(endDate).toLocaleDateString('es-AR');
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -106,7 +111,7 @@ const DashboardPage = () => {
             // Obtiene datos de forma segura: si falta el endpoint o la petición falla,
             // devuelve el valor por defecto. En caso contrario, retorna solo el campo
             // `data` de la respuesta.
-            const safeGet = async (endpoint, defaultData, plantilla) => {
+            const safeGet = async (endpoint, defaultData, plantilla, extraParams = {}) => {
                 if (!endpoint) return defaultData;
                 const params = Object.fromEntries(
                     Object.entries(appliedFilters).filter(([, v]) => v)
@@ -114,6 +119,7 @@ const DashboardPage = () => {
                 if (plantilla) {
                     params.plantilla = plantilla;
                 }
+                Object.assign(params, extraParams);
                 try {
                     const res = await apiClient.get(endpoint, { params });
                     return res.data;
@@ -127,6 +133,7 @@ const DashboardPage = () => {
             const TEMPLATE_DATOS_CONCURSO = 'Datos concurso - Planta y Contratos';
             const TEMPLATE_CONTROL_PLANTA = 'Control de certificaciones - Planta y Contratos';
             const TEMPLATE_EXPEDIENTES = 'Expedientes';
+            const TEMPLATE_SAC_VIAS = 'SAC - Via de captacion';
             const [
                 totalData,
                 ageDistData,
@@ -151,7 +158,8 @@ const DashboardPage = () => {
                 exitTimeRes,
                 topUnitsRes,
                 topInitiatorsData,
-                byTramiteData
+                byTramiteData,
+                sacViaCaptacionData
             ] = await Promise.all([
                 // Datos generales correspondientes a la plantilla "Rama completa - Planta y Contratos"
                 safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_PLANTA_CONTRATOS),
@@ -180,7 +188,9 @@ const DashboardPage = () => {
                 safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_PLANTA),
                 // Expedientes
                 safeGet(funcs.expedientesTopInitiators, [], TEMPLATE_EXPEDIENTES),
-                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES)
+                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES),
+                // SAC
+                safeGet(funcs.sacViaCaptacion, [], TEMPLATE_SAC_VIAS, { startDate, endDate })
             ]);
 
             setTotalAgents(totalData.total);
@@ -207,6 +217,7 @@ const DashboardPage = () => {
             setTopUnitsData(topUnitsRes);
             setExpTopInitiators(topInitiatorsData);
             setExpByTramite(byTramiteData);
+            setSacViaData(sacViaCaptacionData);
 
         } catch (err) {
             setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
@@ -280,8 +291,6 @@ const DashboardPage = () => {
                 : '0 6px 20px rgba(33, 150, 243, 0.2)',
         },
     });
-
-    const { start, end } = getPreviousMonthRange();
 
     if (loading) {
         return (
@@ -379,6 +388,13 @@ const DashboardPage = () => {
                     sx={getTabButtonStyles(5)}
                 >
                     Expedientes
+                </Button>
+                <Button
+                    onClick={() => setTabValue(6)}
+                    startIcon={<PhoneIcon />}
+                    sx={getTabButtonStyles(6)}
+                >
+                    SAC
                 </Button>
             </Box>
 
@@ -567,11 +583,9 @@ const DashboardPage = () => {
         {tabValue === 5 && (
             <Grid container spacing={3}>
                 <Grid item xs={12}>
+                    <MonthCutoffAlert systemName="de expedientes" startDate={startDateFormatted} endDate={endDateFormatted} />
                     <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
                         Expedientes
-                    </Typography>
-                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 3 }}>
-                        Expedientes a mes vencido. Corte del {expStart} al {expEnd}.
                     </Typography>
                 </Grid>
                 <Grid item xs={12} md={6}>
@@ -595,6 +609,32 @@ const DashboardPage = () => {
                             xKey="tramite"
                             barKey="count"
                             title="Cantidad de expedientes según tipo de trámite"
+                            isDarkMode={isDarkMode}
+                            height={400}
+                        />
+                    ) : (
+                        <Typography align="center">Sin datos</Typography>
+                    )}
+                </Grid>
+            </Grid>
+        )}
+
+        {/* Tab 6: SAC */}
+        {tabValue === 6 && (
+            <Grid container spacing={3}>
+                <Grid item xs={12}>
+                    <MonthCutoffAlert systemName="SAC" startDate={startDateFormatted} endDate={endDateFormatted} />
+                    <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
+                        SAC
+                    </Typography>
+                </Grid>
+                <Grid item xs={12}>
+                    {sacViaData.length > 0 ? (
+                        <CustomBarChart
+                            data={sacViaData}
+                            xKey="via"
+                            barKey="total"
+                            title="Análisis de vía de captación"
                             isDarkMode={isDarkMode}
                             height={400}
                         />

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -7,9 +7,7 @@ export const getPreviousMonthRange = () => {
         lastDayPreviousMonth.getMonth(),
         1
     );
-    const format = (d) => d.toLocaleDateString('es-AR');
-    return {
-        start: format(firstDayPreviousMonth),
-        end: format(lastDayPreviousMonth),
-    };
+    const startDate = firstDayPreviousMonth.toISOString().split('T')[0];
+    const endDate = lastDayPreviousMonth.toISOString().split('T')[0];
+    return { startDate, endDate };
 };


### PR DESCRIPTION
## Summary
- ensure previous month range is computed once and shared across backend and frontend
- show month cutoff alerts for SAC and Expedientes sections with start and end dates
- import SAC capture rows by checking Via or Total fields
- define MonthCutoffAlert in a dedicated component and import it into dashboards to avoid redeclaration errors
- wrap MonthCutoffAlert in a Box for consistent spacing
- clarify MonthCutoffAlert import in DashboardPage to avoid local redeclaration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a36bd8f883278507471c1c73280f