### PR TITLE
feat: extend SAC analytics and frontend

### DIFF
--- a/backend/config/defaultFunctions.js
+++ b/backend/config/defaultFunctions.js
@@ -23,5 +23,47 @@ module.exports = [
   { name: 'certificationsTopUnits', description: 'Top unidades de registración', endpoint: '/analytics/certifications/top-units' },
   { name: 'expedientesTopInitiators', description: 'Top iniciadores de expedientes', endpoint: '/analytics/expedientes/top-initiators' },
   { name: 'expedientesByTramite', description: 'Expedientes por tipo de trámite', endpoint: '/analytics/expedientes/by-tramite' },
-  { name: 'sacViaCaptacion', description: 'SAC vía de captación', endpoint: '/analytics/sac/via-captacion' }
+  { name: 'sacViaCaptacion', description: 'SAC vía de captación', endpoint: '/analytics/sac/via-captacion' },
+  { name: 'sacCierreProblemasTopReclamos', description: 'SAC cierre de problemas - top reclamos', endpoint: '/analytics/sac/cierre-problemas/top-reclamos' },
+  { name: 'sacCierreProblemasTopPromedios', description: 'SAC cierre de problemas - top promedios', endpoint: '/analytics/sac/cierre-problemas/top-promedios' },
+  { name: 'sacCierreProblemasTopPendientes', description: 'SAC cierre de problemas - top pendientes', endpoint: '/analytics/sac/cierre-problemas/top-pendientes' },
+  { name: 'sacCierreProblemasTopCerrados', description: 'SAC cierre de problemas - top cerrados', endpoint: '/analytics/sac/cierre-problemas/top-cerrados' },
+  { name: 'sacBocaReceptoraTop', description: 'SAC boca receptora - top cantidad', endpoint: '/analytics/sac/boca-receptora/top' },
+  { name: 'sacFrecuenciaTiposCierre', description: 'SAC frecuencia de tipos de cierre', endpoint: '/analytics/sac/frecuencia-tipos-cierre' },
+  { name: 'sacTemasTopRecibidos', description: 'SAC temas - top recibidos', endpoint: '/analytics/sac/temas/top-recibidos' },
+  { name: 'sacTemasTopVisualizados', description: 'SAC temas - top visualizados', endpoint: '/analytics/sac/temas/top-visualizados' },
+  { name: 'sacTemasTopPendientes', description: 'SAC temas - top pendientes', endpoint: '/analytics/sac/temas/top-pendientes' },
+  { name: 'sacTemasTopProceso', description: 'SAC temas - top en proceso', endpoint: '/analytics/sac/temas/top-proceso' },
+  { name: 'sacTemasTopCerrados', description: 'SAC temas - top cerrados', endpoint: '/analytics/sac/temas/top-cerrados' },
+  { name: 'sacTipoContactoTopRecibidos', description: 'SAC tipo de contacto - top recibidos', endpoint: '/analytics/sac/tipo-contacto/top-recibidos' },
+  { name: 'sacTipoContactoTopCerrados', description: 'SAC tipo de contacto - top cerrados', endpoint: '/analytics/sac/tipo-contacto/top-cerrados' },
+  { name: 'sacLlamadasBarrioTop', description: 'SAC llamadas por barrio - top realizadas', endpoint: '/analytics/sac/llamadas-barrio/top' },
+  { name: 'sacAmbienteTopReclamos', description: 'SAC ambiente - top reclamos', endpoint: '/analytics/sac/secretaria-ambiente/top-reclamos' },
+  { name: 'sacAmbienteTopPromedios', description: 'SAC ambiente - top promedios', endpoint: '/analytics/sac/secretaria-ambiente/top-promedios' },
+  { name: 'sacAmbienteTopPendientes', description: 'SAC ambiente - top pendientes', endpoint: '/analytics/sac/secretaria-ambiente/top-pendientes' },
+  { name: 'sacAmbienteTopCerrados', description: 'SAC ambiente - top cerrados', endpoint: '/analytics/sac/secretaria-ambiente/top-cerrados' },
+  { name: 'sacInfraestructuraTopReclamos', description: 'SAC infraestructura - top reclamos', endpoint: '/analytics/sac/secretaria-infraestructura/top-reclamos' },
+  { name: 'sacInfraestructuraTopPromedios', description: 'SAC infraestructura - top promedios', endpoint: '/analytics/sac/secretaria-infraestructura/top-promedios' },
+  { name: 'sacInfraestructuraTopPendientes', description: 'SAC infraestructura - top pendientes', endpoint: '/analytics/sac/secretaria-infraestructura/top-pendientes' },
+  { name: 'sacInfraestructuraTopCerrados', description: 'SAC infraestructura - top cerrados', endpoint: '/analytics/sac/secretaria-infraestructura/top-cerrados' },
+  {
+    name: 'sacCoordTerritorialTopReclamos',
+    description: 'SAC coordinación territorial - top reclamos',
+    endpoint: '/analytics/sac/coordinacion-territorial/top-reclamos'
+  },
+  {
+    name: 'sacCoordTerritorialTopPromedio',
+    description: 'SAC coordinación territorial - top promedios',
+    endpoint: '/analytics/sac/coordinacion-territorial/top-promedios'
+  },
+  {
+    name: 'sacCoordTerritorialTopPendientes',
+    description: 'SAC coordinación territorial - top pendientes',
+    endpoint: '/analytics/sac/coordinacion-territorial/top-pendientes'
+  },
+  {
+    name: 'sacCoordTerritorialTopCerrados',
+    description: 'SAC coordinación territorial - top cerrados',
+    endpoint: '/analytics/sac/coordinacion-territorial/top-cerrados'
+  }
 ];

--- a/backend/controllers/uploadController.js
+++ b/backend/controllers/uploadController.js
@@ -107,8 +107,14 @@ async function uploadFile(req, res) {
         // Mapear los datos según el mapping de la plantilla, solo si la fila es válida
         let camposClave;
         const templateName = template.name ? template.name.trim().toLowerCase() : '';
-        if (templateName.includes('via de captacion') || templateName.includes('sac')) {
+        if (templateName.includes('via de captacion')) {
           camposClave = ['Via', 'Total'];
+        } else if (templateName.includes('sac')) {
+          const mappingNames = template.mappings.map(m => m.variableName);
+          const descField = mappingNames.find(n => /descripcion|problema|boca|tema|contacto|barrio/i.test(n)) || mappingNames[0];
+          const qtyField = mappingNames.find(n => /cantidad/i.test(n));
+          camposClave = [descField];
+          if (qtyField && qtyField !== descField) camposClave.push(qtyField);
         } else if (templateName.includes('expedientes')) {
           camposClave = ['Numero de expediente', 'Iniciador del Expediente'];
         } else {

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -44,7 +44,33 @@ const {
   getAgentsByExitTime,
   getTopRegistrationUnits,
   notifyDashboardModification,
-  getSacViaCaptacion
+  getSacViaCaptacion,
+  getCierreProblemasTopByReclamos,
+  getCierreProblemasTopByPromedios,
+  getCierreProblemasTopByPendientes,
+  getCierreProblemasTopByCerrados,
+  getBocaReceptoraTop,
+  getFrecuenciaTiposCierre,
+  getTemasTopRecibidos,
+  getTemasTopVisualizados,
+  getTemasTopPendientes,
+  getTemasTopEnProceso,
+  getTemasTopCerrados,
+  getTipoContactoTopRecibidos,
+  getTipoContactoTopCerrados,
+  getLlamadasBarrioTop,
+  getAmbienteTopReclamos,
+  getAmbienteTopPromedios,
+  getAmbienteTopPendientes,
+  getAmbienteTopCerrados,
+  getInfraestructuraTopReclamos,
+  getInfraestructuraTopPromedios,
+  getInfraestructuraTopPendientes,
+  getInfraestructuraTopCerrados,
+  getCoordinacionTopReclamos,
+  getCoordinacionTopPromedios,
+  getCoordinacionTopPendientes,
+  getCoordinacionTopCerrados
 } = require('../controllers/analyticsController');
 
 router.get('/secretarias', authenticateToken, getSecretarias);
@@ -84,6 +110,32 @@ router.get('/certifications/top-units', authenticateToken, getTopRegistrationUni
 
 // Rutas para SAC
 router.get('/sac/via-captacion', authenticateToken, getSacViaCaptacion);
+router.get('/sac/cierre-problemas/top-reclamos', authenticateToken, getCierreProblemasTopByReclamos);
+router.get('/sac/cierre-problemas/top-promedios', authenticateToken, getCierreProblemasTopByPromedios);
+router.get('/sac/cierre-problemas/top-pendientes', authenticateToken, getCierreProblemasTopByPendientes);
+router.get('/sac/cierre-problemas/top-cerrados', authenticateToken, getCierreProblemasTopByCerrados);
+router.get('/sac/boca-receptora/top', authenticateToken, getBocaReceptoraTop);
+router.get('/sac/frecuencia-tipos-cierre', authenticateToken, getFrecuenciaTiposCierre);
+router.get('/sac/temas/top-recibidos', authenticateToken, getTemasTopRecibidos);
+router.get('/sac/temas/top-visualizados', authenticateToken, getTemasTopVisualizados);
+router.get('/sac/temas/top-pendientes', authenticateToken, getTemasTopPendientes);
+router.get('/sac/temas/top-proceso', authenticateToken, getTemasTopEnProceso);
+router.get('/sac/temas/top-cerrados', authenticateToken, getTemasTopCerrados);
+router.get('/sac/tipo-contacto/top-recibidos', authenticateToken, getTipoContactoTopRecibidos);
+router.get('/sac/tipo-contacto/top-cerrados', authenticateToken, getTipoContactoTopCerrados);
+router.get('/sac/llamadas-barrio/top', authenticateToken, getLlamadasBarrioTop);
+router.get('/sac/secretaria-ambiente/top-reclamos', authenticateToken, getAmbienteTopReclamos);
+router.get('/sac/secretaria-ambiente/top-promedios', authenticateToken, getAmbienteTopPromedios);
+router.get('/sac/secretaria-ambiente/top-pendientes', authenticateToken, getAmbienteTopPendientes);
+router.get('/sac/secretaria-ambiente/top-cerrados', authenticateToken, getAmbienteTopCerrados);
+router.get('/sac/secretaria-infraestructura/top-reclamos', authenticateToken, getInfraestructuraTopReclamos);
+router.get('/sac/secretaria-infraestructura/top-promedios', authenticateToken, getInfraestructuraTopPromedios);
+router.get('/sac/secretaria-infraestructura/top-pendientes', authenticateToken, getInfraestructuraTopPendientes);
+router.get('/sac/secretaria-infraestructura/top-cerrados', authenticateToken, getInfraestructuraTopCerrados);
+router.get('/sac/coordinacion-territorial/top-reclamos', authenticateToken, getCoordinacionTopReclamos);
+router.get('/sac/coordinacion-territorial/top-promedios', authenticateToken, getCoordinacionTopPromedios);
+router.get('/sac/coordinacion-territorial/top-pendientes', authenticateToken, getCoordinacionTopPendientes);
+router.get('/sac/coordinacion-territorial/top-cerrados', authenticateToken, getCoordinacionTopCerrados);
 
 // Rutas para Neikes y Beca
 router.get('/agents/by-function-neike-beca', authenticateToken, require('../controllers/analyticsController').getAgentsByFunctionNeikeBeca);

--- a/backend/utils/dateUtils.js
+++ b/backend/utils/dateUtils.js
@@ -12,4 +12,13 @@ function getPreviousMonthRange() {
   return { startDate, endDate };
 }
 
-module.exports = { getPreviousMonthRange };
+function getCurrentMonthRange() {
+  const now = new Date();
+  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
+  const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+  const startDate = firstDay.toISOString().split('T')[0];
+  const endDate = lastDay.toISOString().split('T')[0];
+  return { startDate, endDate };
+}
+
+module.exports = { getPreviousMonthRange, getCurrentMonthRange };

--- a/frontend/src/components/MonthCutoffAlert.jsx
+++ b/frontend/src/components/MonthCutoffAlert.jsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import { Alert, Box, Typography } from '@mui/material';
 
-const MonthCutoffAlert = ({ systemName, startDate, endDate }) => (
-    <Box my={2}>
-        <Alert
-            severity="info"
-            icon={false}
-            sx={{ bgcolor: 'rgba(33,150,243,0.1)', borderLeft: '6px solid #2196f3' }}
-        >
-            <Typography variant="body2" fontWeight={600}>
-                {`Datos tomados del sistema ${systemName} con corte del ${startDate} al ${endDate}.`}
-            </Typography>
-        </Alert>
-    </Box>
-);
+const MonthCutoffAlert = ({ systemName, startDate, endDate }) => {
+    const start = new Date(startDate).toLocaleDateString('es-AR');
+    const end = new Date(endDate).toLocaleDateString('es-AR');
+    return (
+        <Box my={2}>
+            <Alert
+                severity="info"
+                icon={false}
+                sx={{ bgcolor: 'rgba(33,150,243,0.1)', borderLeft: '6px solid #2196f3' }}
+            >
+                <Typography variant="body2" fontWeight={600}>
+                    {`Datos tomados del sistema ${systemName} con corte del ${start} al ${end}.`}
+                </Typography>
+            </Alert>
+        </Box>
+    );
+};
 
 export default MonthCutoffAlert;

--- a/frontend/src/components/SACSection.jsx
+++ b/frontend/src/components/SACSection.jsx
@@ -1,0 +1,452 @@
+import React, { useState, useCallback } from 'react';
+import { Grid, Accordion, AccordionSummary, AccordionDetails, Typography, Alert } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import CustomBarChart from './CustomBarChart';
+import MonthCutoffAlert from './MonthCutoffAlert';
+import apiClient from '../services/api';
+
+const SacSection = ({ sacViaData, funcs, isDarkMode, startDate, endDate }) => {
+  const [cierreReclamos, setCierreReclamos] = useState([]);
+  const [cierrePromedios, setCierrePromedios] = useState([]);
+  const [cierrePendientes, setCierrePendientes] = useState([]);
+  const [cierreCerrados, setCierreCerrados] = useState([]);
+  const [bocaData, setBocaData] = useState([]);
+  const [frecuenciaData, setFrecuenciaData] = useState([]);
+  const [temasRecibidos, setTemasRecibidos] = useState([]);
+  const [temasVisualizados, setTemasVisualizados] = useState([]);
+  const [temasPendientes, setTemasPendientes] = useState([]);
+  const [temasProceso, setTemasProceso] = useState([]);
+  const [temasCerrados, setTemasCerrados] = useState([]);
+  const [contactoRecibidos, setContactoRecibidos] = useState([]);
+  const [contactoCerrados, setContactoCerrados] = useState([]);
+  const [llamadasBarrio, setLlamadasBarrio] = useState([]);
+  const [ambienteReclamos, setAmbienteReclamos] = useState([]);
+  const [ambientePromedios, setAmbientePromedios] = useState([]);
+  const [ambientePendientes, setAmbientePendientes] = useState([]);
+  const [ambienteCerrados, setAmbienteCerrados] = useState([]);
+  const [infraReclamos, setInfraReclamos] = useState([]);
+  const [infraPromedios, setInfraPromedios] = useState([]);
+  const [infraPendientes, setInfraPendientes] = useState([]);
+  const [infraCerrados, setInfraCerrados] = useState([]);
+  const [coordReclamos, setCoordReclamos] = useState([]);
+  const [coordPromedios, setCoordPromedios] = useState([]);
+  const [coordPendientes, setCoordPendientes] = useState([]);
+  const [coordCerrados, setCoordCerrados] = useState([]);
+
+  const safeGet = useCallback(
+    async (endpoint, plantilla) => {
+      if (!endpoint) return [];
+      try {
+        const params = { plantilla };
+        if (startDate && endDate) {
+          params.startDate = startDate;
+          params.endDate = endDate;
+        }
+        const res = await apiClient.get(endpoint, { params });
+        return res.data;
+      } catch {
+        return [];
+      }
+    },
+    [startDate, endDate]
+  );
+
+  const fetchCierre = useCallback(async () => {
+    if (cierreReclamos.length) return;
+    const plantilla = 'SAC - Cierre de problemas';
+    const [r, p, pe, c] = await Promise.all([
+      safeGet(funcs.sacCierreProblemasTopReclamos, plantilla),
+      safeGet(funcs.sacCierreProblemasTopPromedios, plantilla),
+      safeGet(funcs.sacCierreProblemasTopPendientes, plantilla),
+      safeGet(funcs.sacCierreProblemasTopCerrados, plantilla)
+    ]);
+    setCierreReclamos(r);
+    setCierrePromedios(p);
+    setCierrePendientes(pe);
+    setCierreCerrados(c);
+  }, [safeGet, funcs, cierreReclamos.length]);
+
+  const fetchBoca = useCallback(async () => {
+    if (bocaData.length) return;
+    const data = await safeGet(funcs.sacBocaReceptoraTop, 'SAC - Boca receptora');
+    setBocaData(data);
+  }, [safeGet, funcs, bocaData.length]);
+
+  const fetchFrecuencia = useCallback(async () => {
+    if (frecuenciaData.length) return;
+    const data = await safeGet(funcs.sacFrecuenciaTiposCierre, 'SAC - Frecuencia de tipos de cierre');
+    setFrecuenciaData(data);
+  }, [safeGet, funcs, frecuenciaData.length]);
+
+  const fetchTemas = useCallback(async () => {
+    if (temasRecibidos.length) return;
+    const plantilla = 'SAC - Temas';
+    const [r, v, pe, pr, c] = await Promise.all([
+      safeGet(funcs.sacTemasTopRecibidos, plantilla),
+      safeGet(funcs.sacTemasTopVisualizados, plantilla),
+      safeGet(funcs.sacTemasTopPendientes, plantilla),
+      safeGet(funcs.sacTemasTopProceso, plantilla),
+      safeGet(funcs.sacTemasTopCerrados, plantilla)
+    ]);
+    setTemasRecibidos(r);
+    setTemasVisualizados(v);
+    setTemasPendientes(pe);
+    setTemasProceso(pr);
+    setTemasCerrados(c);
+  }, [safeGet, funcs, temasRecibidos.length]);
+
+  const fetchTipoContacto = useCallback(async () => {
+    if (contactoRecibidos.length) return;
+    const plantilla = 'SAC - Discriminacion por tipo de contacto';
+    const [r, c] = await Promise.all([
+      safeGet(funcs.sacTipoContactoTopRecibidos, plantilla),
+      safeGet(funcs.sacTipoContactoTopCerrados, plantilla)
+    ]);
+    setContactoRecibidos(r);
+    setContactoCerrados(c);
+  }, [safeGet, funcs, contactoRecibidos.length]);
+
+  const fetchLlamadasBarrio = useCallback(async () => {
+    if (llamadasBarrio.length) return;
+    const data = await safeGet(funcs.sacLlamadasBarrioTop, 'SAC - Evaluacion de llamadas por barrio');
+    setLlamadasBarrio(data);
+  }, [safeGet, funcs, llamadasBarrio.length]);
+
+  const fetchAmbiente = useCallback(async () => {
+    if (ambienteReclamos.length) return;
+    const plantilla = 'SAC - Secretaria de ambiente y desarrollo sustentable';
+    const [r, p, pe, c] = await Promise.all([
+      safeGet(funcs.sacAmbienteTopReclamos, plantilla),
+      safeGet(funcs.sacAmbienteTopPromedios, plantilla),
+      safeGet(funcs.sacAmbienteTopPendientes, plantilla),
+      safeGet(funcs.sacAmbienteTopCerrados, plantilla)
+    ]);
+    setAmbienteReclamos(r);
+    setAmbientePromedios(p);
+    setAmbientePendientes(pe);
+    setAmbienteCerrados(c);
+  }, [safeGet, funcs, ambienteReclamos.length]);
+
+  const fetchInfraestructura = useCallback(async () => {
+    if (infraReclamos.length) return;
+    const plantilla = 'SAC - Secretaria de infraestructura';
+    const [r, p, pe, c] = await Promise.all([
+      safeGet(funcs.sacInfraestructuraTopReclamos, plantilla),
+      safeGet(funcs.sacInfraestructuraTopPromedios, plantilla),
+      safeGet(funcs.sacInfraestructuraTopPendientes, plantilla),
+      safeGet(funcs.sacInfraestructuraTopCerrados, plantilla)
+    ]);
+    setInfraReclamos(r);
+    setInfraPromedios(p);
+    setInfraPendientes(pe);
+    setInfraCerrados(c);
+  }, [safeGet, funcs, infraReclamos.length]);
+
+  const fetchCoordinacion = useCallback(async () => {
+    if (coordReclamos.length) return;
+    const plantilla = 'SAC - Secretaria de coordinacion de relaciones territoriales';
+    const [r, p, pe, c] = await Promise.all([
+      safeGet(funcs.sacCoordTerritorialTopReclamos, plantilla),
+      safeGet(funcs.sacCoordTerritorialTopPromedio, plantilla),
+      safeGet(funcs.sacCoordTerritorialTopPendientes, plantilla),
+      safeGet(funcs.sacCoordTerritorialTopCerrados, plantilla)
+    ]);
+    setCoordReclamos(r);
+    setCoordPromedios(p);
+    setCoordPendientes(pe);
+    setCoordCerrados(c);
+  }, [safeGet, funcs, coordReclamos.length]);
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        <Typography variant="h4" align="center" fontWeight={700} mt={4}>
+          SAC
+        </Typography>
+        <Alert severity="info" sx={{ my: 2 }}>
+          Este módulo permite analizar los reclamos y gestiones del Sistema de Atención al Ciudadano. Selecciona un panel para ver sus gráficos.
+        </Alert>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>
+              Análisis de vía de captación
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            {sacViaData.length > 0 && (
+              <CustomBarChart
+                data={sacViaData}
+                xKey="via"
+                barKey="total"
+                title="Vía de captación"
+                isDarkMode={isDarkMode}
+                height={400}
+              />
+            )}
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchCierre()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Análisis de cierre por problemas</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={6}>
+                {cierreReclamos.length > 0 && (
+                  <CustomBarChart data={cierreReclamos} xKey="problem" barKey="count" title="Cantidad de reclamos" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {cierrePromedios.length > 0 && (
+                  <CustomBarChart data={cierrePromedios} xKey="problem" barKey="avgClosure" title="Promedios días de cierre" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {cierrePendientes.length > 0 && (
+                  <CustomBarChart data={cierrePendientes} xKey="problem" barKey="pendientes" title="Cantidad de reclamos pendientes" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {cierreCerrados.length > 0 && (
+                  <CustomBarChart data={cierreCerrados} xKey="problem" barKey="cerrados" title="Cantidad de reclamos cerrados" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchBoca()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Análisis por boca receptora</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            {bocaData.length > 0 && (
+              <CustomBarChart data={bocaData} xKey="boca" barKey="cantidad" title="Top 5 bocas con mayor cantidad" isDarkMode={isDarkMode} />
+            )}
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchFrecuencia()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Análisis de frecuencia de tipo de cierre</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            {frecuenciaData.length > 0 && (
+              <CustomBarChart data={frecuenciaData} xKey="tipo" barKey="cantidad" title="Frecuencia de tipos de cierre" isDarkMode={isDarkMode} />
+            )}
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchTemas()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Análisis por temas</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={6}>
+                {temasRecibidos.length > 0 && (
+                  <CustomBarChart data={temasRecibidos} xKey="area" barKey="valor" title="Top 5 temas recibidos por áreas" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {temasVisualizados.length > 0 && (
+                  <CustomBarChart data={temasVisualizados} xKey="area" barKey="valor" title="Top 5 visualizados sobre áreas" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {temasPendientes.length > 0 && (
+                  <CustomBarChart data={temasPendientes} xKey="area" barKey="valor" title="Top 5 temas pendientes sobre áreas" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {temasProceso.length > 0 && (
+                  <CustomBarChart data={temasProceso} xKey="area" barKey="valor" title="Top 5 temas en proceso sobre áreas" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12}>
+                {temasCerrados.length > 0 && (
+                  <CustomBarChart data={temasCerrados} xKey="area" barKey="valor" title="Top 5 temas cerrados sobre áreas" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchTipoContacto()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Discriminación por tipo de contacto</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={6}>
+                {contactoRecibidos.length > 0 && (
+                  <CustomBarChart data={contactoRecibidos} xKey="tipo" barKey="recibidos" title="Contactos recibidos" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {contactoCerrados.length > 0 && (
+                  <CustomBarChart data={contactoCerrados} xKey="tipo" barKey="cerrados" title="Contactos cerrados" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchLlamadasBarrio()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Evaluación de llamadas por barrio</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            {llamadasBarrio.length > 0 && (
+              <CustomBarChart data={llamadasBarrio} xKey="barrio" barKey="realizadas" title="Top 5 barrios por llamadas realizadas" isDarkMode={isDarkMode} />
+            )}
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchAmbiente()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Secretaría de Ambiente y Desarrollo Sustentable</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={6}>
+                {ambienteReclamos.length > 0 && (
+                  <CustomBarChart data={ambienteReclamos} xKey="problem" barKey="count" title="Cantidad de reclamos" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {ambientePromedios.length > 0 && (
+                  <CustomBarChart data={ambientePromedios} xKey="problem" barKey="avgClosure" title="Promedios días de cierre" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {ambientePendientes.length > 0 && (
+                  <CustomBarChart data={ambientePendientes} xKey="problem" barKey="pendientes" title="Cantidad de reclamos pendientes" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {ambienteCerrados.length > 0 && (
+                  <CustomBarChart data={ambienteCerrados} xKey="problem" barKey="cerrados" title="Cantidad de reclamos cerrados" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchInfraestructura()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Secretaría de Infraestructura</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={6}>
+                {infraReclamos.length > 0 && (
+                  <CustomBarChart data={infraReclamos} xKey="problem" barKey="count" title="Cantidad de reclamos" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {infraPromedios.length > 0 && (
+                  <CustomBarChart data={infraPromedios} xKey="problem" barKey="avgClosure" title="Promedios días de cierre" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {infraPendientes.length > 0 && (
+                  <CustomBarChart data={infraPendientes} xKey="problem" barKey="pendientes" title="Cantidad de reclamos pendientes" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {infraCerrados.length > 0 && (
+                  <CustomBarChart data={infraCerrados} xKey="problem" barKey="cerrados" title="Cantidad de reclamos cerrados" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12}>
+        <Accordion onChange={(_, exp) => exp && fetchCoordinacion()}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{ bgcolor: isDarkMode ? 'grey.800' : 'grey.200' }}
+          >
+            <Typography variant="h6" fontWeight={600}>Secretaría de Coordinación de Relaciones Territoriales</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={6}>
+                {coordReclamos.length > 0 && (
+                  <CustomBarChart data={coordReclamos} xKey="problem" barKey="count" title="Cantidad de reclamos" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {coordPromedios.length > 0 && (
+                  <CustomBarChart data={coordPromedios} xKey="problem" barKey="avgClosure" title="Promedios días de cierre" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {coordPendientes.length > 0 && (
+                  <CustomBarChart data={coordPendientes} xKey="problem" barKey="pendientes" title="Cantidad de reclamos pendientes" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+              <Grid item xs={12} md={6}>
+                {coordCerrados.length > 0 && (
+                  <CustomBarChart data={coordCerrados} xKey="problem" barKey="cerrados" title="Cantidad de reclamos cerrados" isDarkMode={isDarkMode} />
+                )}
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default SacSection;

--- a/frontend/src/page/DashboardNeikeBeca.jsx
+++ b/frontend/src/page/DashboardNeikeBeca.jsx
@@ -64,8 +64,6 @@ const DashboardNeikeBeca = () => {
     const [expByTramite, setExpByTramite] = useState([]);
     const [sacViaData, setSacViaData] = useState([]);
     const { startDate, endDate } = getPreviousMonthRange();
-    const startDateFormatted = new Date(startDate).toLocaleDateString('es-AR');
-    const endDateFormatted = new Date(endDate).toLocaleDateString('es-AR');
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -717,7 +715,7 @@ const DashboardNeikeBeca = () => {
         {tabValue === 5 && (
             <Grid container spacing={3}>
                 <Grid item xs={12}>
-                    <MonthCutoffAlert systemName="de expedientes" startDate={startDateFormatted} endDate={endDateFormatted} />
+                    <MonthCutoffAlert systemName="de expedientes" startDate={startDate} endDate={endDate} />
                     <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
                         Expedientes
                     </Typography>
@@ -757,7 +755,7 @@ const DashboardNeikeBeca = () => {
         {tabValue === 6 && (
             <Grid container spacing={3}>
                 <Grid item xs={12}>
-                    <MonthCutoffAlert systemName="SAC" startDate={startDateFormatted} endDate={endDateFormatted} />
+                    <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
                     <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
                         SAC
                     </Typography>

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -17,8 +17,9 @@ import CustomDonutChart from '../components/CustomDonutChart';
 import CustomAreaChart from '../components/CustomAreaChart';
 import DependencyFilter from '../components/DependencyFilter.jsx';
 import MonthCutoffAlert from '../components/MonthCutoffAlert';
+import SacSection from '../components/SACSection';
 import { useLocation } from 'react-router-dom';
-import { getPreviousMonthRange } from '../utils/dateUtils';
+import { getPreviousMonthRange } from '../utils/dateUtils.js';
 
 const DashboardPage = () => {
     const { user } = useAuth();
@@ -64,10 +65,9 @@ const DashboardPage = () => {
     const [topUnitsData, setTopUnitsData] = useState([]);
     const [expTopInitiators, setExpTopInitiators] = useState([]);
     const [expByTramite, setExpByTramite] = useState([]);
+    const [funcs, setFuncs] = useState({});
     const [sacViaData, setSacViaData] = useState([]);
     const { startDate, endDate } = getPreviousMonthRange();
-    const startDateFormatted = new Date(startDate).toLocaleDateString('es-AR');
-    const endDateFormatted = new Date(endDate).toLocaleDateString('es-AR');
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -106,7 +106,8 @@ const DashboardPage = () => {
 
         try {
             const funcRes = await apiClient.get('/functions');
-            const funcs = funcRes.data.reduce((acc, f) => { acc[f.name] = f.endpoint; return acc; }, {});
+            const funcMap = funcRes.data.reduce((acc, f) => { acc[f.name] = f.endpoint; return acc; }, {});
+            setFuncs(funcMap);
 
             // Obtiene datos de forma segura: si falta el endpoint o la petición falla,
             // devuelve el valor por defecto. En caso contrario, retorna solo el campo
@@ -162,35 +163,35 @@ const DashboardPage = () => {
                 sacViaCaptacionData
             ] = await Promise.all([
                 // Datos generales correspondientes a la plantilla "Rama completa - Planta y Contratos"
-                safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.ageDistribution, null, TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.ageByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByEmploymentType, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDependency, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsBySecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsBySubsecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDireccionGeneral, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDireccion, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDepartamento, [], TEMPLATE_PLANTA_CONTRATOS),
-                safeGet(funcs.agentsByDivision, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.totalAgents, { total: 0 }, TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.ageDistribution, null, TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.ageByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsByFunction, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsByEmploymentType, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsByDependency, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsBySecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsBySubsecretaria, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsByDireccionGeneral, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsByDireccion, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsByDepartamento, [], TEMPLATE_PLANTA_CONTRATOS),
+                safeGet(funcMap.agentsByDivision, [], TEMPLATE_PLANTA_CONTRATOS),
                 // Datos para antigüedad y estudios
-                safeGet(funcs.agentsBySeniority, [], TEMPLATE_DATOS_CONCURSO),
-                safeGet(funcs.agentsBySecondaryStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
-                safeGet(funcs.agentsByTertiaryStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
-                safeGet(funcs.agentsByUniversityStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
-                safeGet(funcs.agentsByTopSecretariasUniversity, [], TEMPLATE_DATOS_CONCURSO),
-                safeGet(funcs.agentsByTopSecretariasTertiary, [], TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcMap.agentsBySeniority, [], TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcMap.agentsBySecondaryStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcMap.agentsByTertiaryStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcMap.agentsByUniversityStudies, { conTitulo: 0, otros: 0 }, TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcMap.agentsByTopSecretariasUniversity, [], TEMPLATE_DATOS_CONCURSO),
+                safeGet(funcMap.agentsByTopSecretariasTertiary, [], TEMPLATE_DATOS_CONCURSO),
                 // Datos para control de certificaciones
-                safeGet(funcs.certificationsRegistrationType, [], TEMPLATE_CONTROL_PLANTA),
-                safeGet(funcs.certificationsEntryTime, [], TEMPLATE_CONTROL_PLANTA),
-                safeGet(funcs.certificationsExitTime, [], TEMPLATE_CONTROL_PLANTA),
-                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_PLANTA),
+                safeGet(funcMap.certificationsRegistrationType, [], TEMPLATE_CONTROL_PLANTA),
+                safeGet(funcMap.certificationsEntryTime, [], TEMPLATE_CONTROL_PLANTA),
+                safeGet(funcMap.certificationsExitTime, [], TEMPLATE_CONTROL_PLANTA),
+                safeGet(funcMap.certificationsTopUnits, [], TEMPLATE_CONTROL_PLANTA),
                 // Expedientes
-                safeGet(funcs.expedientesTopInitiators, [], TEMPLATE_EXPEDIENTES),
-                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES),
+                safeGet(funcMap.expedientesTopInitiators, [], TEMPLATE_EXPEDIENTES),
+                safeGet(funcMap.expedientesByTramite, [], TEMPLATE_EXPEDIENTES),
                 // SAC (sin filtros de fecha)
-                safeGet(funcs.sacViaCaptacion, [], TEMPLATE_SAC_VIAS)
+                safeGet(funcMap.sacViaCaptacion, [], TEMPLATE_SAC_VIAS)
             ]);
 
             setTotalAgents(totalData.total);
@@ -334,7 +335,9 @@ const DashboardPage = () => {
                 Análisis detallado de la dotación municipal con gráficos especializados
             </Typography>
 
-            <DependencyFilter filters={filters} onFilter={handleApplyFilters} />
+            {tabValue !== 6 && (
+                <DependencyFilter filters={filters} onFilter={handleApplyFilters} />
+            )}
 
             {/* Navegación por botones */}
             <Box
@@ -583,7 +586,7 @@ const DashboardPage = () => {
         {tabValue === 5 && (
             <Grid container spacing={3}>
                 <Grid item xs={12}>
-                    <MonthCutoffAlert systemName="de expedientes" startDate={startDateFormatted} endDate={endDateFormatted} />
+                    <MonthCutoffAlert systemName="de expedientes" startDate={startDate} endDate={endDate} />
                     <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
                         Expedientes
                     </Typography>
@@ -621,28 +624,13 @@ const DashboardPage = () => {
 
         {/* Tab 6: SAC */}
         {tabValue === 6 && (
-            <Grid container spacing={3}>
-                <Grid item xs={12}>
-                    <MonthCutoffAlert systemName="SAC" startDate={startDateFormatted} endDate={endDateFormatted} />
-                    <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
-                        SAC
-                    </Typography>
-                </Grid>
-                <Grid item xs={12}>
-                    {sacViaData.length > 0 ? (
-                        <CustomBarChart
-                            data={sacViaData}
-                            xKey="via"
-                            barKey="total"
-                            title="Análisis de vía de captación"
-                            isDarkMode={isDarkMode}
-                            height={400}
-                        />
-                    ) : (
-                        <Typography align="center">Sin datos</Typography>
-                    )}
-                </Grid>
-            </Grid>
+            <SacSection
+                sacViaData={sacViaData}
+                funcs={funcs}
+                isDarkMode={isDarkMode}
+                startDate={startDate}
+                endDate={endDate}
+            />
         )}
 
             {/* Tab 1: Análisis de Edad */}

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -11,3 +11,12 @@ export const getPreviousMonthRange = () => {
     const endDate = lastDayPreviousMonth.toISOString().split('T')[0];
     return { startDate, endDate };
 };
+
+export const getCurrentMonthRange = () => {
+    const now = new Date();
+    const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
+    const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+    const startDate = firstDay.toISOString().split('T')[0];
+    const endDate = lastDay.toISOString().split('T')[0];
+    return { startDate, endDate };
+};


### PR DESCRIPTION
## Summary
- expose coordination-territorial SAC analytics endpoints and register them for the frontend
- compute previous-month cutoffs and format date alerts
- standardize SAC chart titles and fetch coordination data on demand
- compute current-month range in dashboard to avoid undefined function error
- ensure SAC section uses previous month range and correct coordination template
- fix DashboardPage import for previous-month range helper to prevent runtime ReferenceError
- conditionally hide the global dependency filter when viewing the SAC tab

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm install` (frontend) *(fails: 403 403 Forbidden - GET https://registry.npmjs.org/mapbox-gl)*
- `npm test` (frontend) *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b599267a7c8327a8f3a3a490af3424