### PR TITLE
feat: add optional end row for import templates

### DIFF
--- a/backend/controllers/uploadController.js
+++ b/backend/controllers/uploadController.js
@@ -96,7 +96,10 @@ async function uploadFile(req, res) {
         }
         // Limpiar datos desde la fila indicada en la plantilla (dataStartRow)
         const data = xlsx.utils.sheet_to_json(worksheet, { header: 1, defval: '' });
-        const datos = data.slice((template.dataStartRow || 2) - 1); // dataStartRow es 2-based
+        const { dataStartRow = 2, dataEndRow } = template;
+        const startIndex = dataStartRow - 1;
+        const endIndex = dataEndRow ? dataEndRow - 1 : data.length - 1;
+        const datos = data.slice(startIndex, endIndex + 1); // incluye fila de inicio y fin
         if (!datos.length) {
           try { fs.unlinkSync(filePath); } catch (e) {}
           resultados.push({ archivo: file.originalname, error: 'No se encontraron datos válidos en el archivo Excel (verifica la fila de inicio en la plantilla).' });

--- a/backend/models/ImportTemplate.js
+++ b/backend/models/ImportTemplate.js
@@ -17,6 +17,16 @@ const importTemplateSchema = new mongoose.Schema({
   name: { type: String, required: true, unique: true, trim: true },
   description: { type: String, trim: true },
   dataStartRow: { type: Number, required: true, default: 2, min: 1 },
+  dataEndRow: {
+    type: Number,
+    min: 1,
+    validate: {
+      validator: function (v) {
+        return v === undefined || v >= this.dataStartRow;
+      },
+      message: 'dataEndRow debe ser mayor o igual a dataStartRow'
+    }
+  },
   sheetName: { type: String, trim: true }, // opcional
   mappings: {
     type: [columnMappingSchema],

--- a/frontend/src/components/TemplateModal.jsx
+++ b/frontend/src/components/TemplateModal.jsx
@@ -33,6 +33,12 @@ function validate(form) {
   if (!Number.isInteger(row) || row < 1) {
     errors.dataStartRow = 'Debe ser un entero ≥ 1';
   }
+  if (form.dataEndRow !== undefined && form.dataEndRow !== '') {
+    const end = Number(form.dataEndRow);
+    if (!Number.isInteger(end) || end < row) {
+      errors.dataEndRow = 'Debe ser un entero ≥ fila inicio';
+    }
+  }
   if (!Array.isArray(form.mappings) || form.mappings.length === 0) {
     errors.mappingsGeneral = 'Agrega al menos un mapeo';
   } else {
@@ -48,7 +54,7 @@ function validate(form) {
 }
 
 const TemplateModal = ({ open, onClose, onSubmit, initialData, isDarkMode, saving = false }) => {
-  const [form, setForm] = useState({ name: '', description: '', dataStartRow: 2, mappings: [] });
+  const [form, setForm] = useState({ name: '', description: '', dataStartRow: 2, dataEndRow: undefined, mappings: [] });
   const [touched, setTouched] = useState({});
   const [initializing, setInitializing] = useState(false);
   const [debouncedForm, setDebouncedForm] = useState(form);
@@ -64,6 +70,7 @@ const TemplateModal = ({ open, onClose, onSubmit, initialData, isDarkMode, savin
         name: initialData.name || '',
         description: initialData.description || '',
         dataStartRow: initialData.dataStartRow ?? 2,
+        dataEndRow: initialData.dataEndRow,
         mappings: Array.isArray(initialData.mappings)
           ? initialData.mappings.map(m => ({
               columnHeader: m.columnHeader || '',
@@ -73,7 +80,7 @@ const TemplateModal = ({ open, onClose, onSubmit, initialData, isDarkMode, savin
           : [],
       });
     } else {
-      setForm({ name: '', description: '', dataStartRow: 2, mappings: [] });
+      setForm({ name: '', description: '', dataStartRow: 2, dataEndRow: undefined, mappings: [] });
     }
     setTouched({});
     const id = setTimeout(() => setInitializing(false), 0);
@@ -123,6 +130,7 @@ const TemplateModal = ({ open, onClose, onSubmit, initialData, isDarkMode, savin
     const hasFieldErrors =
       nowErrors.name ||
       nowErrors.dataStartRow ||
+      nowErrors.dataEndRow ||
       nowErrors.mappingsGeneral ||
       (nowErrors.mappings || []).some(m => Object.keys(m || {}).length);
     if (hasFieldErrors) return;
@@ -193,6 +201,19 @@ const TemplateModal = ({ open, onClose, onSubmit, initialData, isDarkMode, savin
                   inputProps={{ min: 1 }}
                   error={Boolean(touched.all && errors.dataStartRow)}
                   helperText={touched.all && errors.dataStartRow}
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  name="dataEndRow"
+                  label="Fila de fin de datos"
+                  type="number"
+                  value={form.dataEndRow ?? ''}
+                  onChange={e => setField('dataEndRow', e.target.value === '' ? undefined : Number(e.target.value))}
+                  fullWidth
+                  inputProps={{ min: 1 }}
+                  error={Boolean(touched.all && errors.dataEndRow)}
+                  helperText={touched.all && errors.dataEndRow ? errors.dataEndRow : 'Opcional. Dejar en blanco para leer hasta el final'}
                 />
               </Grid>
 

--- a/frontend/src/page/DashboardNeikeBeca.jsx
+++ b/frontend/src/page/DashboardNeikeBeca.jsx
@@ -9,15 +9,11 @@ import BusinessIcon from '@mui/icons-material/Business';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import SchoolIcon from '@mui/icons-material/School';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
-import FolderOpenIcon from '@mui/icons-material/FolderOpen';
-import PhoneIcon from '@mui/icons-material/Phone';
 import StatCard from '../components/StatCard';
 import CustomBarChart from '../components/CustomBarChart';
 import CustomDonutChart from '../components/CustomDonutChart';
 import CustomAreaChart from '../components/CustomAreaChart';
 import DependencyFilter from '../components/DependencyFilter.jsx';
-import MonthCutoffAlert from '../components/MonthCutoffAlert';
-import { getPreviousMonthRange } from '../utils/dateUtils';
 
 const DashboardNeikeBeca = () => {
     const { user } = useAuth();
@@ -60,10 +56,6 @@ const DashboardNeikeBeca = () => {
     const [entryTimeData, setEntryTimeData] = useState([]);
     const [exitTimeData, setExitTimeData] = useState([]);
     const [topUnitsData, setTopUnitsData] = useState([]);
-    const [expTopInitiators, setExpTopInitiators] = useState([]);
-    const [expByTramite, setExpByTramite] = useState([]);
-    const [sacViaData, setSacViaData] = useState([]);
-    const { startDate, endDate } = getPreviousMonthRange();
 
     // Hooks para limpiar dashboard
     const [cleaning, setCleaning] = useState(false);
@@ -128,8 +120,6 @@ const DashboardNeikeBeca = () => {
             const TEMPLATE_NEIKES_BECAS = 'Rama completa - Neikes y Beca';
             const TEMPLATE_DATOS_NEIKES = 'Datos concurso - Neikes y Beca';
             const TEMPLATE_CONTROL_NEIKES = 'Control de certificaciones - Neikes y Becas';
-            const TEMPLATE_EXPEDIENTES = 'Expedientes';
-            const TEMPLATE_SAC_VIAS = 'SAC - Via de captacion';
             const [
                 totalData,
                 ageDistData,
@@ -152,10 +142,7 @@ const DashboardNeikeBeca = () => {
                 regTypeRes,
                 entryTimeRes,
                 exitTimeRes,
-                topUnitsRes,
-                topInitiatorsData,
-                byTramiteData,
-                sacViaCaptacionData
+                topUnitsRes
             ] = await Promise.all([
                 // Datos correspondientes a la plantilla "Rama completa - Neikes y Beca"
                 safeGet(funcs.totalAgents, { total: 0 }, TEMPLATE_NEIKES_BECAS),
@@ -181,12 +168,7 @@ const DashboardNeikeBeca = () => {
                 safeGet(funcs.certificationsRegistrationType, [], TEMPLATE_CONTROL_NEIKES),
                 safeGet(funcs.certificationsEntryTime, [], TEMPLATE_CONTROL_NEIKES),
                 safeGet(funcs.certificationsExitTime, [], TEMPLATE_CONTROL_NEIKES),
-                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_NEIKES),
-                // Expedientes
-                safeGet(funcs.expedientesTopInitiators, [], TEMPLATE_EXPEDIENTES),
-                safeGet(funcs.expedientesByTramite, [], TEMPLATE_EXPEDIENTES),
-                // SAC (sin filtros de fecha)
-                safeGet(funcs.sacViaCaptacion, [], TEMPLATE_SAC_VIAS)
+                safeGet(funcs.certificationsTopUnits, [], TEMPLATE_CONTROL_NEIKES)
             ]);
 
             setTotalAgents(totalData.total);
@@ -211,9 +193,6 @@ const DashboardNeikeBeca = () => {
             setEntryTimeData(entryTimeRes);
             setExitTimeData(exitTimeRes);
             setTopUnitsData(topUnitsRes);
-            setExpTopInitiators(topInitiatorsData);
-            setExpByTramite(byTramiteData);
-            setSacViaData(sacViaCaptacionData);
 
         } catch (err) {
             setError('Error al cargar los datos del dashboard. Por favor, contacta al administrador.');
@@ -360,20 +339,6 @@ const DashboardNeikeBeca = () => {
                     sx={getTabButtonStyles(4)}
                 >
                     Control de certificaciones – Neikes y Becas
-                </Button>
-                <Button
-                    onClick={() => setTabValue(5)}
-                    startIcon={<FolderOpenIcon />}
-                    sx={getTabButtonStyles(5)}
-                >
-                    Expedientes
-                </Button>
-                <Button
-                    onClick={() => setTabValue(6)}
-                    startIcon={<PhoneIcon />}
-                    sx={getTabButtonStyles(6)}
-                >
-                    SAC
                 </Button>
             </Box>
 
@@ -711,71 +676,6 @@ const DashboardNeikeBeca = () => {
             </Grid>
         )}
 
-        {/* Tab 5: Expedientes */}
-        {tabValue === 5 && (
-            <Grid container spacing={3}>
-                <Grid item xs={12}>
-                    <MonthCutoffAlert systemName="de expedientes" startDate={startDate} endDate={endDate} />
-                    <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
-                        Expedientes
-                    </Typography>
-                </Grid>
-                <Grid item xs={12} md={6}>
-                    {expTopInitiators.length > 0 ? (
-                        <CustomBarChart
-                            data={expTopInitiators}
-                            xKey="initiator"
-                            barKey="count"
-                            title="Top 10 áreas con más trámites gestionados"
-                            isDarkMode={isDarkMode}
-                            height={400}
-                        />
-                    ) : (
-                        <Typography align="center">Sin datos</Typography>
-                    )}
-                </Grid>
-                <Grid item xs={12} md={6}>
-                    {expByTramite.length > 0 ? (
-                        <CustomBarChart
-                            data={expByTramite}
-                            xKey="tramite"
-                            barKey="count"
-                            title="Cantidad de expedientes según tipo de trámite"
-                            isDarkMode={isDarkMode}
-                            height={400}
-                        />
-                    ) : (
-                        <Typography align="center">Sin datos</Typography>
-                    )}
-                </Grid>
-            </Grid>
-        )}
-
-        {/* Tab 6: SAC */}
-        {tabValue === 6 && (
-            <Grid container spacing={3}>
-                <Grid item xs={12}>
-                    <MonthCutoffAlert systemName="SAC" startDate={startDate} endDate={endDate} />
-                    <Typography variant="h5" sx={{ mb: 1, fontWeight: 600 }}>
-                        SAC
-                    </Typography>
-                </Grid>
-                <Grid item xs={12}>
-                    {sacViaData.length > 0 ? (
-                        <CustomBarChart
-                            data={sacViaData}
-                            xKey="via"
-                            barKey="total"
-                            title="Análisis de vía de captación"
-                            isDarkMode={isDarkMode}
-                            height={400}
-                        />
-                    ) : (
-                        <Typography align="center">Sin datos</Typography>
-                    )}
-                </Grid>
-            </Grid>
-        )}
 
         {user?.role === 'admin' && (
             <>


### PR DESCRIPTION
## Summary
- allow import templates to specify optional end row with validation
- honor the end row when reading Excel files
- expose end row field in template modal and drop SAC/Expedientes from Neikes y Becas dashboard

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: vitest not found)
- `npm install` (frontend, fails: dependency conflict)


------
https://chatgpt.com/codex/tasks/task_e_68b6f1e9a8cc8327add4ed06a0c69299