### PR TITLE
Clarify age range selector and label rendering

### DIFF
--- a/frontend/src/components/AgeRangeByAreaChart.jsx
+++ b/frontend/src/components/AgeRangeByAreaChart.jsx
@@ -64,7 +64,7 @@ const AgeRangeByAreaChart = ({ rows, isDarkMode }) => {
           <Typography variant="h6" sx={{fontWeight:600,color:isDarkMode?'rgba(255,255,255,0.9)':'rgba(0,0,0,0.8)'}}>
             Distribución por Rangos de Edad según el área - Planta y Contratos
           </Typography>
-          {/* Replace basic <select> with Material UI Select for modern styling */}
+          {/* Material UI Select para un selector acorde al diseño */}
           <FormControl
             size="small"
             sx={{

--- a/frontend/src/components/AverageAgeByFunctionChart.jsx
+++ b/frontend/src/components/AverageAgeByFunctionChart.jsx
@@ -120,7 +120,6 @@ const AverageAgeByFunctionChart = ({ data, isDarkMode }) => {
                 maxBarSize={22}
                 fill={isDarkMode ? '#10b981' : '#059669'}
               >
-                {/* Ensure that Recharts passes positioning props to the label components */}
                 <LabelList
                   dataKey="avg"
                   content={(props) => <AvgAgeLabel {...props} />}


### PR DESCRIPTION
## Summary
- document Material UI select usage for age-range filtering
- streamline average-age chart labels by passing through props directly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bef31a1b888327ba4cf32c76ff4bf0