### PR TITLE
feat: add theme and icons utilities

### DIFF
--- a/frontend/src/ui/icons.js
+++ b/frontend/src/ui/icons.js
@@ -1,0 +1,9 @@
+const icons = {
+  edad: 'cake',
+  personas: 'group',
+  agentes: 'badge',
+  salario: 'attach_money',
+  eficiencia: 'trending_up',
+};
+
+export default icons;

--- a/frontend/src/ui/index.js
+++ b/frontend/src/ui/index.js
@@ -1,0 +1,3 @@
+export { default as theme } from './theme.js';
+export { default as icons } from './icons.js';
+export * from './chart-utils';

--- a/frontend/src/ui/theme.js
+++ b/frontend/src/ui/theme.js
@@ -1,0 +1,14 @@
+const theme = {
+  palette: {
+    primary: '#3b82f6',
+    primaryLight: '#60a5fa',
+  },
+  radii: {
+    sm: 4,
+    md: 8,
+    lg: 12,
+  },
+  boxShadow: '0 6px 18px rgba(2,6,23,0.12)',
+};
+
+export default theme;


### PR DESCRIPTION
## Summary
- add shared theme with primary palette, radii and shadow
- map common metrics to Material Icons
- expose ui utilities via index entry

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c16b6a9a2883279f767263ff019a00