### PR TITLE
feat: add dashboard card component

### DIFF
--- a/frontend/src/components/DashboardCard.jsx
+++ b/frontend/src/components/DashboardCard.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Card, CardContent, Typography, Box } from '@mui/material';
+import icons from '../icons.js';
+import { COLORS, RADII, SHADOWS } from '../theme.js';
+
+const DashboardCard = React.memo(({ title, icon, children, isDarkMode }) => {
+  const IconComponent = icons[icon];
+
+  return (
+    <Card
+      sx={{
+        height: '100%',
+        background: isDarkMode ? COLORS.darkBackground : COLORS.lightBackground,
+        backdropFilter: 'blur(20px)',
+        border: `1px solid ${isDarkMode ? COLORS.darkBorder : COLORS.lightBorder}`,
+        borderRadius: RADII.card,
+        transition: 'all 0.3s ease',
+        '&:hover': {
+          transform: 'translateY(-4px)',
+          boxShadow: isDarkMode ? SHADOWS.dark : SHADOWS.light,
+        },
+      }}
+    >
+      <CardContent sx={{ p: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+          {IconComponent && (
+            <IconComponent
+              sx={{
+                fontSize: 32,
+                mr: 1.5,
+                color: isDarkMode ? COLORS.darkText : COLORS.lightText,
+              }}
+            />
+          )}
+          <Typography
+            variant="h6"
+            sx={{
+              fontWeight: 600,
+              color: isDarkMode ? COLORS.darkText : COLORS.lightText,
+            }}
+          >
+            {title}
+          </Typography>
+        </Box>
+        {children}
+      </CardContent>
+    </Card>
+  );
+});
+
+export default DashboardCard;

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -1,0 +1,25 @@
+import FolderIcon from '@mui/icons-material/Folder';
+import LayersIcon from '@mui/icons-material/Layers';
+import TimelapseIcon from '@mui/icons-material/Timelapse';
+import TagIcon from '@mui/icons-material/Tag';
+import DescriptionIcon from '@mui/icons-material/Description';
+import PeopleIcon from '@mui/icons-material/People';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import AnalyticsIcon from '@mui/icons-material/Analytics';
+import SettingsIcon from '@mui/icons-material/Settings';
+import InfoIcon from '@mui/icons-material/Info';
+
+const icons = {
+  folder: FolderIcon,
+  layers: LayersIcon,
+  timelapse: TimelapseIcon,
+  tag: TagIcon,
+  description: DescriptionIcon,
+  people: PeopleIcon,
+  dashboard: DashboardIcon,
+  analytics: AnalyticsIcon,
+  settings: SettingsIcon,
+  info: InfoIcon,
+};
+
+export default icons;

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,0 +1,23 @@
+export const COLORS = {
+  lightBackground: 'rgba(255, 255, 255, 0.9)',
+  darkBackground: 'rgba(45, 55, 72, 0.8)',
+  lightBorder: 'rgba(0, 0, 0, 0.08)',
+  darkBorder: 'rgba(255, 255, 255, 0.1)',
+  lightText: 'rgba(0, 0, 0, 0.8)',
+  darkText: 'rgba(255, 255, 255, 0.9)',
+};
+
+export const RADII = {
+  card: 3,
+};
+
+export const SHADOWS = {
+  light: '0 12px 40px rgba(0, 0, 0, 0.15)',
+  dark: '0 12px 40px rgba(0, 0, 0, 0.4)',
+};
+
+export default {
+  COLORS,
+  RADII,
+  SHADOWS,
+};


### PR DESCRIPTION
## Summary
- add reusable DashboardCard component
- centralize theme colors, radii and shadows
- provide icon name to component mapping

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16b6d667883278f10851439018406