### PR TITLE
feat: enhance age range chart with dashboard card and pagination

### DIFF
--- a/frontend/src/components/AgeRangeByAreaChart.jsx
+++ b/frontend/src/components/AgeRangeByAreaChart.jsx
@@ -1,10 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import {
-  Card,
-  CardContent,
-  Typography,
   Box,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -18,11 +14,14 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  LabelList
+  LabelList,
 } from 'recharts';
 import KeyboardArrowDownRounded from '@mui/icons-material/KeyboardArrowDownRounded';
 import CheckRounded from '@mui/icons-material/CheckRounded';
-import { formatMiles, formatPct } from '../ui/chart-utils';
+import DashboardCard from './DashboardCard.jsx';
+import PaginationControls from './PaginationControls.jsx';
+import theme from '../theme.js';
+import { formatMiles, formatPct, axisStyle, gridStyle } from '../ui/chart-utils';
 
 const AGE_BUCKETS = [
   '18-25',
@@ -33,16 +32,16 @@ const AGE_BUCKETS = [
   '65+',
   'No tiene datos',
 ];
-// Margen derecho dinámico para alojar etiquetas fuera de la barra
 const MIN_RIGHT = 160;
 const MAX_RIGHT = 240;
 
 const AgeRangeByAreaChart = ({ rows, isDarkMode }) => {
   const [range, setRange] = useState('36-45');
+  const colors = isDarkMode ? theme.dark : theme.light;
 
   const agregados = useMemo(() => {
     const acc = new Map();
-    rows.forEach(r => {
+    rows.forEach((r) => {
       if (r.range === range) {
         const dep = r.dependencia || 'Sin dependencia';
         acc.set(dep, (acc.get(dep) || 0) + r.count);
@@ -51,31 +50,31 @@ const AgeRangeByAreaChart = ({ rows, isDarkMode }) => {
     return Array.from(acc, ([dependencia, cantidad]) => ({ dependencia, cantidad }));
   }, [rows, range]);
 
-  const ordenados = useMemo(() => agregados.sort((a,b)=>b.cantidad-a.cantidad), [agregados]);
-  const total = useMemo(() => ordenados.reduce((s,d)=>s+d.cantidad,0), [ordenados]);
+  const ordenados = useMemo(() => agregados.sort((a, b) => b.cantidad - a.cantidad), [agregados]);
+  const total = useMemo(() => ordenados.reduce((s, d) => s + d.cantidad, 0), [ordenados]);
 
   const PAGE = 10;
   const [page, setPage] = useState(0);
   const totalPages = Math.max(1, Math.ceil(ordenados.length / PAGE));
-  const pageData = useMemo(() => ordenados.slice(page*PAGE, (page+1)*PAGE), [ordenados,page]);
+  const pageData = useMemo(() => ordenados.slice(page * PAGE, (page + 1) * PAGE), [ordenados, page]);
 
-  React.useEffect(()=>setPage(0),[range]);
+  React.useEffect(() => setPage(0), [range]);
 
-  // Calcula un margen derecho dinámico en función del texto de las etiquetas
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map(d => `${formatMiles(d.cantidad)} (${formatPct((d.cantidad||0) / (total || 1))})`);
-    const maxChars = Math.max(...labels.map(t => t.length));
-    const approxWidth = maxChars * 7 + 20; // 7px por carácter + padding
+    const labels = pageData.map(
+      (d) => `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (total || 1))})`
+    );
+    const maxChars = Math.max(...labels.map((t) => t.length));
+    const approxWidth = maxChars * 7 + 20;
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
   }, [pageData, total]);
 
-  // Etiqueta personalizada: afuera a la derecha, anclada al final de la barra
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, value = 0 } = props;
     const label = `${formatMiles(Number(value))} (${formatPct(Number(value) / Number(total || 1))})`;
     const RIGHT_PAD = 8;
-    const xText = x + width + RIGHT_PAD; // justo después del final de la barra
+    const xText = x + width + RIGHT_PAD;
     const yText = y + (height || 0) / 2;
     const color = isDarkMode ? '#ffffff' : '#0f172a';
     return (
@@ -95,187 +94,193 @@ const AgeRangeByAreaChart = ({ rows, isDarkMode }) => {
   };
 
   return (
-    <Card sx={{background:isDarkMode?'rgba(45,55,72,0.8)':'rgba(255,255,255,0.9)',backdropFilter:'blur(20px)',border:isDarkMode?'1px solid rgba(255,255,255,0.1)':'1px solid rgba(0,0,0,0.08)',borderRadius:3}}>
-      <CardContent sx={{p:3}}>
-        {/** Las etiquetas de valores se dibujan al final de cada barra */}
-        <Box className="flex items-center justify-between gap-3" sx={{mb:2}}>
-          <Typography variant="h6" sx={{fontWeight:600,color:isDarkMode?'rgba(255,255,255,0.9)':'rgba(0,0,0,0.8)'}}>
-            Distribución por Rangos de Edad según el área - Planta y Contratos
-          </Typography>
-          {/* Selector con estilo moderno */}
-          <FormControl
-            size="small"
-            variant="outlined"
-            sx={{ minWidth: 170, mt: 1 }}
+    <DashboardCard
+      icon="bar_chart"
+      title="Distribución por Rangos de Edad según el área - Planta y Contratos"
+      isDarkMode={isDarkMode}
+      action={
+        <FormControl size="small" variant="outlined" sx={{ minWidth: 170, mt: 1 }}>
+          <InputLabel
+            id="range-label"
+            sx={{
+              color: colors.select.text,
+              '&.Mui-focused': {
+                color: colors.select.focusBorder,
+              },
+            }}
           >
-            <InputLabel
-              id="range-label"
-              sx={{
-                color: isDarkMode ? 'rgba(255,255,255,0.8)' : 'rgba(0,0,0,0.7)',
-                '&.Mui-focused': {
-                  color: isDarkMode ? '#86efac' : '#059669',
-                },
-              }}
-            >
-              Rango de edad
-            </InputLabel>
-            <Select
-              labelId="range-label"
-              id="range-select"
-              value={range}
-              label="Rango de edad"
-              onChange={(e) => setRange(e.target.value)}
-              IconComponent={KeyboardArrowDownRounded}
-              MenuProps={{
-                PaperProps: {
-                  elevation: 0,
-                  sx: {
-                    mt: 0.5,
-                    borderRadius: 2,
-                    border: isDarkMode ? '1px solid rgba(255,255,255,0.1)' : '1px solid rgba(0,0,0,0.08)',
-                    backgroundColor: isDarkMode ? 'rgba(15,23,42,0.98)' : 'rgba(255,255,255,0.98)',
-                    color: isDarkMode ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.9)',
-                    boxShadow: isDarkMode
-                      ? '0 8px 24px rgba(0,0,0,0.35)'
-                      : '0 8px 24px rgba(0,0,0,0.14)'
-                  },
-                },
-                MenuListProps: {
-                  dense: true,
-                  sx: { py: 0.5 }
-                },
-                disableScrollLock: true,
-                keepMounted: true,
-                TransitionProps: { timeout: 120 },
-              }}
-              sx={{
-                borderRadius: 9999,
-                pr: 4,
-                px: 1.5,
-                height: 36,
-                color: isDarkMode ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.85)',
-                backgroundColor: isDarkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.03)',
-                transition: 'all .2s ease',
-                '& .MuiSelect-select': { py: 0.5 },
-                '& .MuiOutlinedInput-notchedOutline': {
-                  borderColor: isDarkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.2)',
-                },
-                '&:hover .MuiOutlinedInput-notchedOutline': {
-                  borderColor: isDarkMode ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)',
-                },
-                '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                  borderColor: isDarkMode ? '#86efac' : '#059669',
-                },
-                '& .MuiSvgIcon-root': {
-                  color: isDarkMode ? 'rgba(255,255,255,0.85)' : 'rgba(0,0,0,0.6)'
-                },
-                '&.Mui-focused': {
+            Rango de edad
+          </InputLabel>
+          <Select
+            labelId="range-label"
+            id="range-select"
+            value={range}
+            label="Rango de edad"
+            onChange={(e) => setRange(e.target.value)}
+            IconComponent={KeyboardArrowDownRounded}
+            MenuProps={{
+              PaperProps: {
+                elevation: 0,
+                sx: {
+                  mt: 0.5,
+                  borderRadius: 2,
+                  border: isDarkMode
+                    ? '1px solid rgba(255,255,255,0.1)'
+                    : '1px solid rgba(0,0,0,0.08)',
+                  backgroundColor: isDarkMode
+                    ? 'rgba(15,23,42,0.98)'
+                    : 'rgba(255,255,255,0.98)',
+                  color: colors.select.text,
                   boxShadow: isDarkMode
-                    ? '0 0 0 3px rgba(134,239,172,0.25)'
-                    : '0 0 0 3px rgba(5,150,105,0.15)'
-                }
-              }}
-            >
-              {AGE_BUCKETS.map((b) => (
-                <MenuItem
-                  key={b}
-                  value={b}
-                  dense
-                  disableRipple
-                  sx={{
-                    mx: 0.75,
-                    my: 0.25,
-                    px: 1.5,
-                    py: 0.75,
-                    borderRadius: 1.5,
-                    fontSize: 14,
-                    fontWeight: 500,
-                    color: isDarkMode ? 'rgba(255,255,255,0.9)' : 'rgba(15,23,42,0.9)',
-                    '&.Mui-selected': {
-                      backgroundColor: isDarkMode ? 'rgba(16,185,129,0.18)' : 'rgba(5,150,105,0.12)',
-                      color: isDarkMode ? '#eafff5' : '#064e3b',
-                      '&:hover': {
-                        backgroundColor: isDarkMode ? 'rgba(16,185,129,0.22)' : 'rgba(5,150,105,0.16)'
-                      }
-                    }
-                  }}
-                >
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    {range === b && (
-                      <CheckRounded fontSize="small" sx={{ color: isDarkMode ? '#86efac' : '#059669' }} />
-                    )}
-                    <span>{b}</span>
-                  </Box>
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Box>
-        <Box sx={{ height: 520 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={pageData} layout="vertical" margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }} barCategoryGap={10}>
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}
-              />
-              <XAxis type="number" domain={[0, (max)=>Math.ceil(max*1.2)]} allowDecimals={false} tickFormatter={formatMiles} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)' }} />
-              <YAxis type="category" dataKey="dependencia" width={260} tickLine={false} interval={0} tick={{ fontSize:12, fill: isDarkMode? 'rgba(255,255,255,0.7)': 'rgba(0,0,0,0.7)' }} tickFormatter={(v)=> v.length>32? v.slice(0,32)+'…':v} />
-              <Tooltip
-                wrapperStyle={{ outline: 'none' }}
-                content={({ active, payload }) => {
-                  if (!active || !payload?.length) return null;
-                  const bg = isDarkMode ? 'rgba(45, 55, 72, 0.95)' : 'rgba(255, 255, 255, 0.95)';
-                  const bd = isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.1)';
-                  const fg = isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)';
-                  const shadow = isDarkMode
-                    ? '0 12px 40px rgba(0, 0, 0, 0.4)'
-                    : '0 12px 40px rgba(0, 0, 0, 0.15)';
-                  return (
-                    <div
-                      style={{
-                        backgroundColor: bg,
-                        border: bd,
-                        color: fg,
-                        borderRadius: 8,
-                        padding: '10px 12px',
-                        boxShadow: shadow,
-                        minWidth: 220,
-                      }}
-                    >
-                      <div style={{ fontWeight: 600, marginBottom: 6 }}>
-                        Rango de edad: {range}
-                      </div>
-                      <div>Cantidad de agentes: {formatMiles(payload[0].value)}</div>
-                      <div>Porcentaje: {formatPct(payload[0].value / (total || 1))}</div>
-                    </div>
-                  );
+                    ? '0 8px 24px rgba(0,0,0,0.35)'
+                    : '0 8px 24px rgba(0,0,0,0.14)',
+                },
+              },
+              MenuListProps: {
+                dense: true,
+                sx: { py: 0.5 },
+              },
+              disableScrollLock: true,
+              keepMounted: true,
+              TransitionProps: { timeout: 120 },
+            }}
+            sx={{
+              borderRadius: 9999,
+              pr: 4,
+              px: 1.5,
+              height: 36,
+              color: colors.select.text,
+              backgroundColor: colors.select.bg,
+              transition: 'all .2s ease',
+              '& .MuiSelect-select': { py: 0.5 },
+              '& .MuiOutlinedInput-notchedOutline': {
+                borderColor: colors.select.border,
+              },
+              '&:hover .MuiOutlinedInput-notchedOutline': {
+                borderColor: colors.select.borderHover,
+              },
+              '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                borderColor: colors.select.focusBorder,
+              },
+              '& .MuiSvgIcon-root': {
+                color: colors.select.icon,
+              },
+              '&.Mui-focused': {
+                boxShadow: colors.select.focusShadow,
+              },
+            }}
+          >
+            {AGE_BUCKETS.map((b) => (
+              <MenuItem
+                key={b}
+                value={b}
+                dense
+                disableRipple
+                sx={{
+                  mx: 0.75,
+                  my: 0.25,
+                  px: 1.5,
+                  py: 0.75,
+                  borderRadius: 1.5,
+                  fontSize: 14,
+                  fontWeight: 500,
+                  color: colors.select.text,
+                  '&.Mui-selected': {
+                    backgroundColor: colors.select.selectedBg,
+                    color: colors.select.selectedColor,
+                    '&:hover': {
+                      backgroundColor: colors.select.selectedHoverBg,
+                    },
+                  },
                 }}
-              />
-              <Bar
-                dataKey="cantidad"
-                maxBarSize={22}
-                fill="#00C49F"
               >
-                <LabelList
-                  dataKey="cantidad"
-                  content={(props) => <EndOutsideLabel {...props} />}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {ordenados.length > PAGE && (
-          <Box sx={{display:'flex',justifyContent:'flex-end',gap:1,mt:2}}>
-            <Button variant="outlined" size="small" onClick={()=>setPage(p=>Math.max(0,p-1))} disabled={page===0}>← Anterior</Button>
-            <Typography variant="body2" sx={{alignSelf:'center'}}>
-              Página {page+1} de {totalPages}
-            </Typography>
-            <Button variant="outlined" size="small" onClick={()=>setPage(p=>Math.min(totalPages-1,p+1))} disabled={page===totalPages-1}>Siguiente →</Button>
-          </Box>
-        )}
-      </CardContent>
-    </Card>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  {range === b && (
+                    <CheckRounded fontSize="small" sx={{ color: colors.select.focusBorder }} />
+                  )}
+                  <span>{b}</span>
+                </Box>
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      }
+    >
+      <Box sx={{ height: 520 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
+          >
+            <CartesianGrid {...gridStyle(isDarkMode)} horizontal={false} />
+            <XAxis
+              {...axisStyle(isDarkMode)}
+              type="number"
+              domain={[0, (max) => Math.ceil(max * 1.2)]}
+              allowDecimals={false}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisStyle(isDarkMode)}
+              type="category"
+              dataKey="dependencia"
+              width={260}
+              tickLine={false}
+              interval={0}
+              tickFormatter={(v) => (v.length > 32 ? v.slice(0, 32) + '…' : v)}
+            />
+            <Tooltip
+              wrapperStyle={{ outline: 'none' }}
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null;
+                const bg = isDarkMode ? 'rgba(45, 55, 72, 0.95)' : 'rgba(255, 255, 255, 0.95)';
+                const bd = isDarkMode
+                  ? '1px solid rgba(255, 255, 255, 0.1)'
+                  : '1px solid rgba(0, 0, 0, 0.1)';
+                const fg = isDarkMode
+                  ? 'rgba(255, 255, 255, 0.9)'
+                  : 'rgba(0, 0, 0, 0.8)';
+                const shadow = isDarkMode
+                  ? '0 12px 40px rgba(0, 0, 0, 0.4)'
+                  : '0 12px 40px rgba(0, 0, 0, 0.15)';
+                return (
+                  <div
+                    style={{
+                      backgroundColor: bg,
+                      border: bd,
+                      color: fg,
+                      borderRadius: 8,
+                      padding: '10px 12px',
+                      boxShadow: shadow,
+                      minWidth: 220,
+                    }}
+                  >
+                    <div style={{ fontWeight: 600, marginBottom: 6 }}>
+                      Rango de edad: {range}
+                    </div>
+                    <div>Cantidad de agentes: {formatMiles(payload[0].value)}</div>
+                    <div>Porcentaje: {formatPct(payload[0].value / (total || 1))}</div>
+                  </div>
+                );
+              }}
+            />
+            <Bar dataKey="cantidad" maxBarSize={22} fill="#00C49F">
+              <LabelList dataKey="cantidad" content={(props) => <EndOutsideLabel {...props} />} />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {ordenados.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onChange={setPage}
+          isDarkMode={isDarkMode}
+        />
+      )}
+    </DashboardCard>
   );
 };
 

--- a/frontend/src/components/DashboardCard.jsx
+++ b/frontend/src/components/DashboardCard.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Card, CardContent, Box, Typography, Icon } from '@mui/material';
+import theme from '../theme.js';
+
+const DashboardCard = ({ title, icon, action, isDarkMode, children }) => {
+  const colors = isDarkMode ? theme.dark : theme.light;
+  return (
+    <Card
+      sx={{
+        background: isDarkMode ? 'rgba(45,55,72,0.8)' : 'rgba(255,255,255,0.9)',
+        backdropFilter: 'blur(20px)',
+        border: isDarkMode
+          ? '1px solid rgba(255,255,255,0.1)'
+          : '1px solid rgba(0,0,0,0.08)',
+        borderRadius: 3,
+      }}
+    >
+      <CardContent sx={{ p: 3 }}>
+        {(title || action) && (
+          <Box className="flex items-center justify-between gap-3" sx={{ mb: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+              {icon && <Icon sx={{ color: colors.button.border }}>{icon}</Icon>}
+              {title && (
+                <Typography
+                  variant="h6"
+                  sx={{
+                    fontWeight: 600,
+                    color: isDarkMode
+                      ? 'rgba(255,255,255,0.9)'
+                      : 'rgba(0,0,0,0.8)',
+                  }}
+                >
+                  {title}
+                </Typography>
+              )}
+            </Box>
+            {action}
+          </Box>
+        )}
+        {children}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DashboardCard;

--- a/frontend/src/components/PaginationControls.jsx
+++ b/frontend/src/components/PaginationControls.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import theme from '../theme.js';
+
+const PaginationControls = ({ page, totalPages, onChange, isDarkMode }) => {
+  const colors = isDarkMode ? theme.dark : theme.light;
+  const handlePrev = () => onChange(p => Math.max(0, p - 1));
+  const handleNext = () => onChange(p => Math.min(totalPages - 1, p + 1));
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
+      <Button
+        variant="outlined"
+        size="small"
+        onClick={handlePrev}
+        disabled={page === 0}
+        sx={{
+          borderColor: colors.button.border,
+          color: colors.button.color,
+          '&:hover': {
+            borderColor: colors.button.border,
+            backgroundColor: colors.button.hoverBg,
+          },
+        }}
+      >
+        ← Anterior
+      </Button>
+      <Typography variant="body2" sx={{ alignSelf: 'center' }}>
+        Página {page + 1} de {totalPages}
+      </Typography>
+      <Button
+        variant="outlined"
+        size="small"
+        onClick={handleNext}
+        disabled={page === totalPages - 1}
+        sx={{
+          borderColor: colors.button.border,
+          color: colors.button.color,
+          '&:hover': {
+            borderColor: colors.button.border,
+            backgroundColor: colors.button.hoverBg,
+          },
+        }}
+      >
+        Siguiente →
+      </Button>
+    </Box>
+  );
+};
+
+export default PaginationControls;

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,0 +1,42 @@
+const theme = {
+  light: {
+    select: {
+      bg: 'rgba(0,0,0,0.03)',
+      text: 'rgba(0,0,0,0.85)',
+      border: 'rgba(0,0,0,0.2)',
+      borderHover: 'rgba(0,0,0,0.35)',
+      focusBorder: '#059669',
+      icon: 'rgba(0,0,0,0.6)',
+      focusShadow: '0 0 0 3px rgba(5,150,105,0.15)',
+      selectedBg: 'rgba(5,150,105,0.12)',
+      selectedColor: '#064e3b',
+      selectedHoverBg: 'rgba(5,150,105,0.16)'
+    },
+    button: {
+      color: '#059669',
+      border: '#059669',
+      hoverBg: 'rgba(5,150,105,0.04)'
+    }
+  },
+  dark: {
+    select: {
+      bg: 'rgba(255,255,255,0.06)',
+      text: 'rgba(255,255,255,0.9)',
+      border: 'rgba(255,255,255,0.15)',
+      borderHover: 'rgba(255,255,255,0.35)',
+      focusBorder: '#86efac',
+      icon: 'rgba(255,255,255,0.85)',
+      focusShadow: '0 0 0 3px rgba(134,239,172,0.25)',
+      selectedBg: 'rgba(16,185,129,0.18)',
+      selectedColor: '#eafff5',
+      selectedHoverBg: 'rgba(16,185,129,0.22)'
+    },
+    button: {
+      color: '#86efac',
+      border: '#86efac',
+      hoverBg: 'rgba(134,239,172,0.1)'
+    }
+  }
+};
+
+export default theme;

--- a/frontend/src/ui/chart-utils.tsx
+++ b/frontend/src/ui/chart-utils.tsx
@@ -82,3 +82,13 @@ export const UnifiedTooltip: React.FC<{active?:boolean; payload?:any[]; label?:s
     </div>
   );
 };
+
+export const axisStyle = (dark: boolean) => ({
+  tick: { fill: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)', fontSize: 12 },
+  axisLine: { stroke: dark ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.3)' }
+});
+
+export const gridStyle = (dark: boolean) => ({
+  strokeDasharray: '0 0',
+  stroke: dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'
+});


### PR DESCRIPTION
## Summary
- replace chart card with reusable DashboardCard component
- centralize select and button colors in theme.js
- add PaginationControls and apply axis/grid utilities to age range chart

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden downloading mapbox-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68c16b713f8883279bf9d1c3fe45de23