### PR TITLE
fix: remove duplicate export block in chart utils

### DIFF
--- a/frontend/src/ui/chart-utils.tsx
+++ b/frontend/src/ui/chart-utils.tsx
@@ -133,13 +133,3 @@ export const UnifiedTooltip: React.FC<{
     </div>
   );
 };
-
-export const axisStyle = (dark: boolean) => ({
-  tick: { fill: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)', fontSize: 12 },
-  axisLine: { stroke: dark ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.3)' }
-});
-
-export const gridStyle = (dark: boolean) => ({
-  strokeDasharray: '0 0',
-  stroke: dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'
-});


### PR DESCRIPTION
## Summary
- remove duplicated axis/grid style exports from chart-utils

## Testing
- `npm test` *(fails: vitest not found; dependency installation blocked)*
- `npm run dev` *(fails: vite not found; installing dependencies from registry is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1724fb2008327988481e0dd87cfa4