### PR TITLE
refactor: use theme context in dashboard components

### DIFF
--- a/frontend/src/components/AgeRangeByAreaChart.jsx
+++ b/frontend/src/components/AgeRangeByAreaChart.jsx
@@ -20,7 +20,7 @@ import KeyboardArrowDownRounded from '@mui/icons-material/KeyboardArrowDownRound
 import CheckRounded from '@mui/icons-material/CheckRounded';
 import DashboardCard from './DashboardCard.jsx';
 import PaginationControls from './PaginationControls.jsx';
-import theme from '../theme.js';
+import { useTheme } from '../context/ThemeContext.jsx';
 import { formatMiles, formatPct, axisStyle, gridStyle } from '../ui/chart-utils';
 
 const AGE_BUCKETS = [
@@ -37,7 +37,21 @@ const MAX_RIGHT = 240;
 
 const AgeRangeByAreaChart = ({ rows, isDarkMode }) => {
   const [range, setRange] = useState('36-45');
-  const colors = isDarkMode ? theme.dark : theme.light;
+  const { theme } = useTheme();
+  const colors = {
+    select: {
+      text: theme.palette.text.primary,
+      focusBorder: theme.palette.primary.main,
+      border: theme.palette.divider,
+      borderHover: theme.palette.primary.main,
+      bg: theme.palette.background.paper,
+      icon: theme.palette.text.primary,
+      focusShadow: `0 0 0 2px ${theme.palette.primary.main}33`,
+      selectedBg: theme.palette.action.selected,
+      selectedColor: theme.palette.text.primary,
+      selectedHoverBg: theme.palette.action.hover,
+    },
+  };
 
   const agregados = useMemo(() => {
     const acc = new Map();

--- a/frontend/src/components/DashboardCard.jsx
+++ b/frontend/src/components/DashboardCard.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { Card, CardContent, Box, Typography, Icon } from '@mui/material';
-import theme from '../theme.js';
+import { useTheme } from '../context/ThemeContext.jsx';
 
 const DashboardCard = ({ title, icon, action, isDarkMode, children }) => {
-  const colors = isDarkMode ? theme.dark : theme.light;
+  const { theme } = useTheme();
+  const colors = {
+    button: {
+      border: theme.palette.primary.main,
+    },
+  };
   return (
     <Card
       sx={{

--- a/frontend/src/components/PaginationControls.jsx
+++ b/frontend/src/components/PaginationControls.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { Box, Button, Typography } from '@mui/material';
-import theme from '../theme.js';
+import { useTheme } from '../context/ThemeContext.jsx';
 
 const PaginationControls = ({ page, totalPages, onChange, isDarkMode }) => {
-  const colors = isDarkMode ? theme.dark : theme.light;
+  const { theme } = useTheme();
+  const colors = {
+    button: {
+      border: theme.palette.primary.main,
+      color: theme.palette.primary.main,
+      hoverBg: theme.palette.action.hover,
+    },
+  };
   const handlePrev = () => onChange(p => Math.max(0, p - 1));
   const handleNext = () => onChange(p => Math.min(totalPages - 1, p + 1));
 


### PR DESCRIPTION
## Summary
- use ThemeContext palette in AgeRangeByAreaChart select styles
- pull palette from ThemeContext in DashboardCard and PaginationControls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c174340de88327a36b573d4073f94e