### PR TITLE
Increase page size for agent bar charts

### DIFF
--- a/frontend/src/components/AgentsByDepartamentoBarChart.jsx
+++ b/frontend/src/components/AgentsByDepartamentoBarChart.jsx
@@ -1,91 +1,263 @@
-import React, { useMemo, useState } from 'react';
-import { Card, CardContent, Typography, Box, Button, Chip } from '@mui/material';
-import ApartmentIcon from '@mui/icons-material/Apartment';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LabelList } from 'recharts';
-import { formatMiles, formatPct, UnifiedTooltip } from '../ui/chart-utils';
+import React, { useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Button,
+  Chip,
+} from "@mui/material";
+import ApartmentIcon from "@mui/icons-material/Apartment";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+} from "recharts";
+import { formatMiles, formatPct, UnifiedTooltip } from "../ui/chart-utils";
 
-const COLOR = '#f43f5e';
+const COLOR = "#f43f5e";
 
 const AgentsByDepartamentoBarChart = ({ data, isDarkMode }) => {
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
-      departamento: (d.departamento ?? '').toString().trim() || 'Sin especificar',
+      departamento:
+        (d.departamento ?? "").toString().trim() || "Sin especificar",
       cantidad: Number(d.count || 0),
     }));
     return rows.sort((a, b) => b.cantidad - a.cantidad);
   }, [data]);
 
-    const [page, setPage] = useState(0);
-    const PAGE = 5;
-    const totalPages = Math.ceil((chartData.length || 0) / PAGE) || 1;
-    const pageData = useMemo(() => chartData.slice(page * PAGE, (page + 1) * PAGE), [chartData, page]);
-    const grandTotal = useMemo(() => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0), [chartData]);
+  const [page, setPage] = useState(0);
+  const PAGE = 20;
+  const totalPages = Math.ceil((chartData.length || 0) / PAGE) || 1;
+  const pageData = useMemo(
+    () => chartData.slice(page * PAGE, (page + 1) * PAGE),
+    [chartData, page],
+  );
+  const grandTotal = useMemo(
+    () => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0),
+    [chartData],
+  );
 
-    const MIN_RIGHT = 140;
-    const MAX_RIGHT = 240;
-    const dynamicRight = React.useMemo(() => {
-      if (!pageData?.length) return MIN_RIGHT;
-      const labels = pageData.map((d) => `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`);
-      const maxChars = Math.max(...labels.map((t) => t.length));
-      const approxWidth = maxChars * 7 + 20;
-      return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
-    }, [pageData, grandTotal]);
+  const MIN_RIGHT = 140;
+  const MAX_RIGHT = 240;
+  const dynamicRight = React.useMemo(() => {
+    if (!pageData?.length) return MIN_RIGHT;
+    const labels = pageData.map(
+      (d) =>
+        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    );
+    const maxChars = Math.max(...labels.map((t) => t.length));
+    const approxWidth = maxChars * 7 + 20;
+    return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
+  }, [pageData, grandTotal]);
 
-    const EndOutsideLabel = (props) => {
-      const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
-      const row = pageData?.[index] || {};
-      const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
-      const color = isDarkMode ? '#ffffff' : '#0f172a';
-      return (
-        <text x={x + width + 8} y={y + (height || 0) / 2} fontSize={12} textAnchor="start" dominantBaseline="central" fill={color} fontWeight="600" pointerEvents="none">{label}</text>
-      );
-    };
-
+  const EndOutsideLabel = (props) => {
+    const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
+    const row = pageData?.[index] || {};
+    const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
+    const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
-      <Card sx={{ height: '100%', background: isDarkMode ? 'rgba(45, 55, 72, 0.8)' : 'rgba(255, 255, 255, 0.9)', backdropFilter: 'blur(20px)', border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.08)', borderLeft: `6px solid ${COLOR}`, borderRadius: 3, transition: 'all 0.3s ease', '&:hover': { transform: 'translateY(-4px)', boxShadow: isDarkMode ? '0 12px 40px rgba(0, 0, 0, 0.4)' : '0 12px 40px rgba(0, 0, 0, 0.15)' } }}>
-        <CardContent sx={{ p: 3 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25 }}>
-            <ApartmentIcon sx={{ color: COLOR }} />
-            <Typography variant="h6" align="center" sx={{ fontWeight: 600, color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)' }}>
-              Agentes por Departamento - Planta y Contratos
-            </Typography>
-            <Chip label="Departamento" size="small" variant="outlined" sx={{ borderColor: COLOR, color: COLOR }} />
-          </Box>
-          <Typography variant="body2" align="center" sx={{ mb: 2, color: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)' }}>
-            {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      <text
+        x={x + width + 8}
+        y={y + (height || 0) / 2}
+        fontSize={12}
+        textAnchor="start"
+        dominantBaseline="central"
+        fill={color}
+        fontWeight="600"
+        pointerEvents="none"
+      >
+        {label}
+      </text>
+    );
+  };
+
+  return (
+    <Card
+      sx={{
+        height: "100%",
+        background: isDarkMode
+          ? "rgba(45, 55, 72, 0.8)"
+          : "rgba(255, 255, 255, 0.9)",
+        backdropFilter: "blur(20px)",
+        border: isDarkMode
+          ? "1px solid rgba(255, 255, 255, 0.1)"
+          : "1px solid rgba(0, 0, 0, 0.08)",
+        borderLeft: `6px solid ${COLOR}`,
+        borderRadius: 3,
+        transition: "all 0.3s ease",
+        "&:hover": {
+          transform: "translateY(-4px)",
+          boxShadow: isDarkMode
+            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
+            : "0 12px 40px rgba(0, 0, 0, 0.15)",
+        },
+      }}
+    >
+      <CardContent sx={{ p: 3 }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 1.25,
+          }}
+        >
+          <ApartmentIcon sx={{ color: COLOR }} />
+          <Typography
+            variant="h6"
+            align="center"
+            sx={{
+              fontWeight: 600,
+              color: isDarkMode
+                ? "rgba(255, 255, 255, 0.9)"
+                : "rgba(0, 0, 0, 0.8)",
+            }}
+          >
+            Agentes por Departamento - Planta y Contratos
           </Typography>
-          <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={pageData} layout="vertical" margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }} barCategoryGap={10}>
-                <CartesianGrid horizontal={false} strokeDasharray="0 0" stroke={isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'} />
-                <XAxis type="number" domain={[0, (max) => Math.ceil((max || 0) * 1.2)]} allowDecimals={false} tickFormatter={formatMiles} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)' }} />
-                <YAxis type="category" dataKey="departamento" width={240} tickLine={false} interval={0} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)', fontSize: 12 }} />
-                <Tooltip wrapperStyle={{ outline: 'none' }} content={({ active, payload }) => (
-                  <UnifiedTooltip active={active} payload={payload} dark={isDarkMode} label={`Departamento: ${payload?.[0]?.payload?.departamento || 'Sin especificar'}`}>
+          <Chip
+            label="Departamento"
+            size="small"
+            variant="outlined"
+            sx={{ borderColor: COLOR, color: COLOR }}
+          />
+        </Box>
+        <Typography
+          variant="body2"
+          align="center"
+          sx={{
+            mb: 2,
+            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+          }}
+        >
+          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+        </Typography>
+        <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={pageData}
+              layout="vertical"
+              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+              barCategoryGap={10}
+            >
+              <CartesianGrid
+                horizontal={false}
+                strokeDasharray="0 0"
+                stroke={
+                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
+                }
+              />
+              <XAxis
+                type="number"
+                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+                allowDecimals={false}
+                tickFormatter={formatMiles}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                }}
+              />
+              <YAxis
+                type="category"
+                dataKey="departamento"
+                width={240}
+                tickLine={false}
+                interval={0}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                  fontSize: 12,
+                }}
+              />
+              <Tooltip
+                wrapperStyle={{ outline: "none" }}
+                content={({ active, payload }) => (
+                  <UnifiedTooltip
+                    active={active}
+                    payload={payload}
+                    dark={isDarkMode}
+                    label={`Departamento: ${payload?.[0]?.payload?.departamento || "Sin especificar"}`}
+                  >
                     {payload?.length && (
                       <>
-                        <div>Cantidad de agentes: {formatMiles(payload[0].payload.cantidad)}</div>
-                        <div>Porcentaje: {formatPct((payload[0].payload.cantidad || 0) / (grandTotal || 1))}</div>
+                        <div>
+                          Cantidad de agentes:{" "}
+                          {formatMiles(payload[0].payload.cantidad)}
+                        </div>
+                        <div>
+                          Porcentaje:{" "}
+                          {formatPct(
+                            (payload[0].payload.cantidad || 0) /
+                              (grandTotal || 1),
+                          )}
+                        </div>
                       </>
                     )}
                   </UnifiedTooltip>
-                )} />
-                <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                  <LabelList dataKey="cantidad" content={(p) => <EndOutsideLabel {...p} />} />
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+                )}
+              />
+              <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
+                <LabelList
+                  dataKey="cantidad"
+                  content={(p) => <EndOutsideLabel {...p} />}
+                />
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </Box>
+        {chartData.length > PAGE && (
+          <Box
+            sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}
+          >
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(244,63,94,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+            >
+              « Anterior
+            </Button>
+            <Typography variant="body2" sx={{ alignSelf: "center" }}>
+              Página {page + 1} de {totalPages}
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(244,63,94,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page === totalPages - 1}
+            >
+              Siguiente »
+            </Button>
           </Box>
-          {chartData.length > PAGE && (
-            <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
-              <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(244,63,94,0.08)' } }} onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0}>« Anterior</Button>
-              <Typography variant="body2" sx={{ alignSelf: 'center' }}>Página {page + 1} de {totalPages}</Typography>
-              <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(244,63,94,0.08)' } }} onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))} disabled={page === totalPages - 1}>Siguiente »</Button>
-            </Box>
-          )}
-        </CardContent>
-      </Card>
-    );
+        )}
+      </CardContent>
+    </Card>
+  );
 };
 
 export default AgentsByDepartamentoBarChart;

--- a/frontend/src/components/AgentsByDependencyBarChart.jsx
+++ b/frontend/src/components/AgentsByDependencyBarChart.jsx
@@ -1,31 +1,56 @@
-import React, { useMemo, useState } from 'react';
-import { Card, CardContent, Typography, Box, Button, Chip } from '@mui/material';
-import HubIcon from '@mui/icons-material/Hub';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LabelList } from 'recharts';
-import { formatMiles, formatPct, UnifiedTooltip } from '../ui/chart-utils';
+import React, { useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Button,
+  Chip,
+} from "@mui/material";
+import HubIcon from "@mui/icons-material/Hub";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+} from "recharts";
+import { formatMiles, formatPct, UnifiedTooltip } from "../ui/chart-utils";
 
-const COLOR = '#6366f1';
+const COLOR = "#6366f1";
 
 const AgentsByDependencyBarChart = ({ data, isDarkMode }) => {
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
-      dependency: (d.dependency ?? '').toString().trim() || 'Sin especificar',
+      dependency: (d.dependency ?? "").toString().trim() || "Sin especificar",
       cantidad: Number(d.count || 0),
     }));
     return rows.sort((a, b) => b.cantidad - a.cantidad);
   }, [data]);
 
   const [page, setPage] = useState(0);
-  const PAGE = 5;
+  const PAGE = 20;
   const totalPages = Math.ceil((chartData.length || 0) / PAGE) || 1;
-  const pageData = useMemo(() => chartData.slice(page * PAGE, (page + 1) * PAGE), [chartData, page]);
-  const grandTotal = useMemo(() => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0), [chartData]);
+  const pageData = useMemo(
+    () => chartData.slice(page * PAGE, (page + 1) * PAGE),
+    [chartData, page],
+  );
+  const grandTotal = useMemo(
+    () => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0),
+    [chartData],
+  );
 
   const MIN_RIGHT = 140;
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map((d) => `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`);
+    const labels = pageData.map(
+      (d) =>
+        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
@@ -35,52 +60,198 @@ const AgentsByDependencyBarChart = ({ data, isDarkMode }) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
     const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
-    const color = isDarkMode ? '#ffffff' : '#0f172a';
+    const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
-      <text x={x + width + 8} y={y + (height || 0) / 2} fontSize={12} textAnchor="start" dominantBaseline="central" fill={color} fontWeight="600" pointerEvents="none">{label}</text>
+      <text
+        x={x + width + 8}
+        y={y + (height || 0) / 2}
+        fontSize={12}
+        textAnchor="start"
+        dominantBaseline="central"
+        fill={color}
+        fontWeight="600"
+        pointerEvents="none"
+      >
+        {label}
+      </text>
     );
   };
 
   return (
-    <Card sx={{ height: '100%', background: isDarkMode ? 'rgba(45, 55, 72, 0.8)' : 'rgba(255, 255, 255, 0.9)', backdropFilter: 'blur(20px)', border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.08)', borderLeft: `6px solid ${COLOR}`, borderRadius: 3, transition: 'all 0.3s ease', '&:hover': { transform: 'translateY(-4px)', boxShadow: isDarkMode ? '0 12px 40px rgba(0, 0, 0, 0.4)' : '0 12px 40px rgba(0, 0, 0, 0.15)' } }}>
+    <Card
+      sx={{
+        height: "100%",
+        background: isDarkMode
+          ? "rgba(45, 55, 72, 0.8)"
+          : "rgba(255, 255, 255, 0.9)",
+        backdropFilter: "blur(20px)",
+        border: isDarkMode
+          ? "1px solid rgba(255, 255, 255, 0.1)"
+          : "1px solid rgba(0, 0, 0, 0.08)",
+        borderLeft: `6px solid ${COLOR}`,
+        borderRadius: 3,
+        transition: "all 0.3s ease",
+        "&:hover": {
+          transform: "translateY(-4px)",
+          boxShadow: isDarkMode
+            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
+            : "0 12px 40px rgba(0, 0, 0, 0.15)",
+        },
+      }}
+    >
       <CardContent sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25 }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 1.25,
+          }}
+        >
           <HubIcon sx={{ color: COLOR }} />
-          <Typography variant="h6" align="center" sx={{ fontWeight: 600, color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)' }}>
+          <Typography
+            variant="h6"
+            align="center"
+            sx={{
+              fontWeight: 600,
+              color: isDarkMode
+                ? "rgba(255, 255, 255, 0.9)"
+                : "rgba(0, 0, 0, 0.8)",
+            }}
+          >
             Agentes por Dependencia - Planta y Contratos
           </Typography>
-          <Chip label="Dependencia" size="small" variant="outlined" sx={{ borderColor: COLOR, color: COLOR }} />
+          <Chip
+            label="Dependencia"
+            size="small"
+            variant="outlined"
+            sx={{ borderColor: COLOR, color: COLOR }}
+          />
         </Box>
-        <Typography variant="body2" align="center" sx={{ mb: 2, color: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)' }}>
+        <Typography
+          variant="body2"
+          align="center"
+          sx={{
+            mb: 2,
+            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+          }}
+        >
           {chartData.length} categorías • {formatMiles(grandTotal)} agentes
         </Typography>
         <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={pageData} layout="vertical" margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }} barCategoryGap={10}>
-              <CartesianGrid horizontal={false} strokeDasharray="0 0" stroke={isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'} />
-              <XAxis type="number" domain={[0, (max) => Math.ceil((max || 0) * 1.2)]} allowDecimals={false} tickFormatter={formatMiles} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)' }} />
-              <YAxis type="category" dataKey="dependency" width={240} tickLine={false} interval={0} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)', fontSize: 12 }} />
-              <Tooltip wrapperStyle={{ outline: 'none' }} content={({ active, payload }) => (
-                <UnifiedTooltip active={active} payload={payload} dark={isDarkMode} label={`Dependencia: ${payload?.[0]?.payload?.dependency || 'Sin especificar'}`}>
-                  {payload?.length && (
-                    <>
-                      <div>Cantidad de agentes: {formatMiles(payload[0].payload.cantidad)}</div>
-                      <div>Porcentaje: {formatPct((payload[0].payload.cantidad || 0) / (grandTotal || 1))}</div>
-                    </>
-                  )}
-                </UnifiedTooltip>
-              )} />
+            <BarChart
+              data={pageData}
+              layout="vertical"
+              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+              barCategoryGap={10}
+            >
+              <CartesianGrid
+                horizontal={false}
+                strokeDasharray="0 0"
+                stroke={
+                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
+                }
+              />
+              <XAxis
+                type="number"
+                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+                allowDecimals={false}
+                tickFormatter={formatMiles}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                }}
+              />
+              <YAxis
+                type="category"
+                dataKey="dependency"
+                width={240}
+                tickLine={false}
+                interval={0}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                  fontSize: 12,
+                }}
+              />
+              <Tooltip
+                wrapperStyle={{ outline: "none" }}
+                content={({ active, payload }) => (
+                  <UnifiedTooltip
+                    active={active}
+                    payload={payload}
+                    dark={isDarkMode}
+                    label={`Dependencia: ${payload?.[0]?.payload?.dependency || "Sin especificar"}`}
+                  >
+                    {payload?.length && (
+                      <>
+                        <div>
+                          Cantidad de agentes:{" "}
+                          {formatMiles(payload[0].payload.cantidad)}
+                        </div>
+                        <div>
+                          Porcentaje:{" "}
+                          {formatPct(
+                            (payload[0].payload.cantidad || 0) /
+                              (grandTotal || 1),
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </UnifiedTooltip>
+                )}
+              />
               <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList dataKey="cantidad" content={(p) => <EndOutsideLabel {...p} />} />
+                <LabelList
+                  dataKey="cantidad"
+                  content={(p) => <EndOutsideLabel {...p} />}
+                />
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </Box>
         {chartData.length > PAGE && (
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
-            <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(99,102,241,0.08)' } }} onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0}>« Anterior</Button>
-            <Typography variant="body2" sx={{ alignSelf: 'center' }}>Página {page + 1} de {totalPages}</Typography>
-            <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(99,102,241,0.08)' } }} onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))} disabled={page === totalPages - 1}>Siguiente »</Button>
+          <Box
+            sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}
+          >
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(99,102,241,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+            >
+              « Anterior
+            </Button>
+            <Typography variant="body2" sx={{ alignSelf: "center" }}>
+              Página {page + 1} de {totalPages}
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(99,102,241,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page === totalPages - 1}
+            >
+              Siguiente »
+            </Button>
           </Box>
         )}
       </CardContent>

--- a/frontend/src/components/AgentsByDireccionBarChart.jsx
+++ b/frontend/src/components/AgentsByDireccionBarChart.jsx
@@ -1,31 +1,56 @@
-import React, { useMemo, useState } from 'react';
-import { Card, CardContent, Typography, Box, Button, Chip } from '@mui/material';
-import AltRouteIcon from '@mui/icons-material/AltRoute';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LabelList } from 'recharts';
-import { formatMiles, formatPct, UnifiedTooltip } from '../ui/chart-utils';
+import React, { useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Button,
+  Chip,
+} from "@mui/material";
+import AltRouteIcon from "@mui/icons-material/AltRoute";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+} from "recharts";
+import { formatMiles, formatPct, UnifiedTooltip } from "../ui/chart-utils";
 
-const COLOR = '#06b6d4';
+const COLOR = "#06b6d4";
 
 const AgentsByDireccionBarChart = ({ data, isDarkMode }) => {
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
-      direccion: (d.direccion ?? '').toString().trim() || 'Sin especificar',
+      direccion: (d.direccion ?? "").toString().trim() || "Sin especificar",
       cantidad: Number(d.count || 0),
     }));
     return rows.sort((a, b) => b.cantidad - a.cantidad);
   }, [data]);
 
   const [page, setPage] = useState(0);
-  const PAGE = 5;
+  const PAGE = 20;
   const totalPages = Math.ceil((chartData.length || 0) / PAGE) || 1;
-  const pageData = useMemo(() => chartData.slice(page * PAGE, (page + 1) * PAGE), [chartData, page]);
-  const grandTotal = useMemo(() => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0), [chartData]);
+  const pageData = useMemo(
+    () => chartData.slice(page * PAGE, (page + 1) * PAGE),
+    [chartData, page],
+  );
+  const grandTotal = useMemo(
+    () => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0),
+    [chartData],
+  );
 
   const MIN_RIGHT = 140;
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map((d) => `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`);
+    const labels = pageData.map(
+      (d) =>
+        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
@@ -35,52 +60,198 @@ const AgentsByDireccionBarChart = ({ data, isDarkMode }) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
     const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
-    const color = isDarkMode ? '#ffffff' : '#0f172a';
+    const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
-      <text x={x + width + 8} y={y + (height || 0) / 2} fontSize={12} textAnchor="start" dominantBaseline="central" fill={color} fontWeight="600" pointerEvents="none">{label}</text>
+      <text
+        x={x + width + 8}
+        y={y + (height || 0) / 2}
+        fontSize={12}
+        textAnchor="start"
+        dominantBaseline="central"
+        fill={color}
+        fontWeight="600"
+        pointerEvents="none"
+      >
+        {label}
+      </text>
     );
   };
 
   return (
-    <Card sx={{ height: '100%', background: isDarkMode ? 'rgba(45, 55, 72, 0.8)' : 'rgba(255, 255, 255, 0.9)', backdropFilter: 'blur(20px)', border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.08)', borderLeft: `6px solid ${COLOR}`, borderRadius: 3, transition: 'all 0.3s ease', '&:hover': { transform: 'translateY(-4px)', boxShadow: isDarkMode ? '0 12px 40px rgba(0, 0, 0, 0.4)' : '0 12px 40px rgba(0, 0, 0, 0.15)' } }}>
+    <Card
+      sx={{
+        height: "100%",
+        background: isDarkMode
+          ? "rgba(45, 55, 72, 0.8)"
+          : "rgba(255, 255, 255, 0.9)",
+        backdropFilter: "blur(20px)",
+        border: isDarkMode
+          ? "1px solid rgba(255, 255, 255, 0.1)"
+          : "1px solid rgba(0, 0, 0, 0.08)",
+        borderLeft: `6px solid ${COLOR}`,
+        borderRadius: 3,
+        transition: "all 0.3s ease",
+        "&:hover": {
+          transform: "translateY(-4px)",
+          boxShadow: isDarkMode
+            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
+            : "0 12px 40px rgba(0, 0, 0, 0.15)",
+        },
+      }}
+    >
       <CardContent sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25 }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 1.25,
+          }}
+        >
           <AltRouteIcon sx={{ color: COLOR }} />
-          <Typography variant="h6" align="center" sx={{ fontWeight: 600, color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)' }}>
+          <Typography
+            variant="h6"
+            align="center"
+            sx={{
+              fontWeight: 600,
+              color: isDarkMode
+                ? "rgba(255, 255, 255, 0.9)"
+                : "rgba(0, 0, 0, 0.8)",
+            }}
+          >
             Agentes por direccion - Planta y Contratos
           </Typography>
-          <Chip label="Dirección" size="small" variant="outlined" sx={{ borderColor: COLOR, color: COLOR }} />
+          <Chip
+            label="Dirección"
+            size="small"
+            variant="outlined"
+            sx={{ borderColor: COLOR, color: COLOR }}
+          />
         </Box>
-        <Typography variant="body2" align="center" sx={{ mb: 2, color: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)' }}>
+        <Typography
+          variant="body2"
+          align="center"
+          sx={{
+            mb: 2,
+            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+          }}
+        >
           {chartData.length} categorías • {formatMiles(grandTotal)} agentes
         </Typography>
         <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={pageData} layout="vertical" margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }} barCategoryGap={10}>
-              <CartesianGrid horizontal={false} strokeDasharray="0 0" stroke={isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'} />
-              <XAxis type="number" domain={[0, (max) => Math.ceil((max || 0) * 1.2)]} allowDecimals={false} tickFormatter={formatMiles} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)' }} />
-              <YAxis type="category" dataKey="direccion" width={240} tickLine={false} interval={0} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)', fontSize: 12 }} />
-              <Tooltip wrapperStyle={{ outline: 'none' }} content={({ active, payload }) => (
-                <UnifiedTooltip active={active} payload={payload} dark={isDarkMode} label={`Dirección: ${payload?.[0]?.payload?.direccion || 'Sin especificar'}`}>
-                  {payload?.length && (
-                    <>
-                      <div>Cantidad de agentes: {formatMiles(payload[0].payload.cantidad)}</div>
-                      <div>Porcentaje: {formatPct((payload[0].payload.cantidad || 0) / (grandTotal || 1))}</div>
-                    </>
-                  )}
-                </UnifiedTooltip>
-              )} />
+            <BarChart
+              data={pageData}
+              layout="vertical"
+              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+              barCategoryGap={10}
+            >
+              <CartesianGrid
+                horizontal={false}
+                strokeDasharray="0 0"
+                stroke={
+                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
+                }
+              />
+              <XAxis
+                type="number"
+                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+                allowDecimals={false}
+                tickFormatter={formatMiles}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                }}
+              />
+              <YAxis
+                type="category"
+                dataKey="direccion"
+                width={240}
+                tickLine={false}
+                interval={0}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                  fontSize: 12,
+                }}
+              />
+              <Tooltip
+                wrapperStyle={{ outline: "none" }}
+                content={({ active, payload }) => (
+                  <UnifiedTooltip
+                    active={active}
+                    payload={payload}
+                    dark={isDarkMode}
+                    label={`Dirección: ${payload?.[0]?.payload?.direccion || "Sin especificar"}`}
+                  >
+                    {payload?.length && (
+                      <>
+                        <div>
+                          Cantidad de agentes:{" "}
+                          {formatMiles(payload[0].payload.cantidad)}
+                        </div>
+                        <div>
+                          Porcentaje:{" "}
+                          {formatPct(
+                            (payload[0].payload.cantidad || 0) /
+                              (grandTotal || 1),
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </UnifiedTooltip>
+                )}
+              />
               <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList dataKey="cantidad" content={(p) => <EndOutsideLabel {...p} />} />
+                <LabelList
+                  dataKey="cantidad"
+                  content={(p) => <EndOutsideLabel {...p} />}
+                />
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </Box>
         {chartData.length > PAGE && (
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
-            <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(6,182,212,0.08)' } }} onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0}>« Anterior</Button>
-            <Typography variant="body2" sx={{ alignSelf: 'center' }}>Página {page + 1} de {totalPages}</Typography>
-            <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(6,182,212,0.08)' } }} onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))} disabled={page === totalPages - 1}>Siguiente »</Button>
+          <Box
+            sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}
+          >
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(6,182,212,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+            >
+              « Anterior
+            </Button>
+            <Typography variant="body2" sx={{ alignSelf: "center" }}>
+              Página {page + 1} de {totalPages}
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(6,182,212,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page === totalPages - 1}
+            >
+              Siguiente »
+            </Button>
           </Box>
         )}
       </CardContent>

--- a/frontend/src/components/AgentsByDireccionGeneralBarChart.jsx
+++ b/frontend/src/components/AgentsByDireccionGeneralBarChart.jsx
@@ -1,31 +1,57 @@
-import React, { useMemo, useState } from 'react';
-import { Card, CardContent, Typography, Box, Button, Chip } from '@mui/material';
-import CorporateFareIcon from '@mui/icons-material/CorporateFare';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LabelList } from 'recharts';
-import { formatMiles, formatPct, UnifiedTooltip } from '../ui/chart-utils';
+import React, { useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Button,
+  Chip,
+} from "@mui/material";
+import CorporateFareIcon from "@mui/icons-material/CorporateFare";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+} from "recharts";
+import { formatMiles, formatPct, UnifiedTooltip } from "../ui/chart-utils";
 
-const COLOR = '#a855f7';
+const COLOR = "#a855f7";
 
 const AgentsByDireccionGeneralBarChart = ({ data, isDarkMode }) => {
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
-      direccionGeneral: (d.direccionGeneral ?? '').toString().trim() || 'Sin especificar',
+      direccionGeneral:
+        (d.direccionGeneral ?? "").toString().trim() || "Sin especificar",
       cantidad: Number(d.count || 0),
     }));
     return rows.sort((a, b) => b.cantidad - a.cantidad);
   }, [data]);
 
   const [page, setPage] = useState(0);
-  const PAGE = 5;
+  const PAGE = 20;
   const totalPages = Math.ceil((chartData.length || 0) / PAGE) || 1;
-  const pageData = useMemo(() => chartData.slice(page * PAGE, (page + 1) * PAGE), [chartData, page]);
-  const grandTotal = useMemo(() => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0), [chartData]);
+  const pageData = useMemo(
+    () => chartData.slice(page * PAGE, (page + 1) * PAGE),
+    [chartData, page],
+  );
+  const grandTotal = useMemo(
+    () => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0),
+    [chartData],
+  );
 
   const MIN_RIGHT = 140;
   const MAX_RIGHT = 260;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map((d) => `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`);
+    const labels = pageData.map(
+      (d) =>
+        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
@@ -35,52 +61,198 @@ const AgentsByDireccionGeneralBarChart = ({ data, isDarkMode }) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
     const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
-    const color = isDarkMode ? '#ffffff' : '#0f172a';
+    const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
-      <text x={x + width + 8} y={y + (height || 0) / 2} fontSize={12} textAnchor="start" dominantBaseline="central" fill={color} fontWeight="600" pointerEvents="none">{label}</text>
+      <text
+        x={x + width + 8}
+        y={y + (height || 0) / 2}
+        fontSize={12}
+        textAnchor="start"
+        dominantBaseline="central"
+        fill={color}
+        fontWeight="600"
+        pointerEvents="none"
+      >
+        {label}
+      </text>
     );
   };
 
   return (
-    <Card sx={{ height: '100%', background: isDarkMode ? 'rgba(45, 55, 72, 0.8)' : 'rgba(255, 255, 255, 0.9)', backdropFilter: 'blur(20px)', border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.08)', borderLeft: `6px solid ${COLOR}`, borderRadius: 3, transition: 'all 0.3s ease', '&:hover': { transform: 'translateY(-4px)', boxShadow: isDarkMode ? '0 12px 40px rgba(0, 0, 0, 0.4)' : '0 12px 40px rgba(0, 0, 0, 0.15)' } }}>
+    <Card
+      sx={{
+        height: "100%",
+        background: isDarkMode
+          ? "rgba(45, 55, 72, 0.8)"
+          : "rgba(255, 255, 255, 0.9)",
+        backdropFilter: "blur(20px)",
+        border: isDarkMode
+          ? "1px solid rgba(255, 255, 255, 0.1)"
+          : "1px solid rgba(0, 0, 0, 0.08)",
+        borderLeft: `6px solid ${COLOR}`,
+        borderRadius: 3,
+        transition: "all 0.3s ease",
+        "&:hover": {
+          transform: "translateY(-4px)",
+          boxShadow: isDarkMode
+            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
+            : "0 12px 40px rgba(0, 0, 0, 0.15)",
+        },
+      }}
+    >
       <CardContent sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25 }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 1.25,
+          }}
+        >
           <CorporateFareIcon sx={{ color: COLOR }} />
-          <Typography variant="h6" align="center" sx={{ fontWeight: 600, color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)' }}>
+          <Typography
+            variant="h6"
+            align="center"
+            sx={{
+              fontWeight: 600,
+              color: isDarkMode
+                ? "rgba(255, 255, 255, 0.9)"
+                : "rgba(0, 0, 0, 0.8)",
+            }}
+          >
             Agentes por direccion general - Planta y Contratos
           </Typography>
-          <Chip label="Dirección General" size="small" variant="outlined" sx={{ borderColor: COLOR, color: COLOR }} />
+          <Chip
+            label="Dirección General"
+            size="small"
+            variant="outlined"
+            sx={{ borderColor: COLOR, color: COLOR }}
+          />
         </Box>
-        <Typography variant="body2" align="center" sx={{ mb: 2, color: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)' }}>
+        <Typography
+          variant="body2"
+          align="center"
+          sx={{
+            mb: 2,
+            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+          }}
+        >
           {chartData.length} categorías • {formatMiles(grandTotal)} agentes
         </Typography>
         <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={pageData} layout="vertical" margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }} barCategoryGap={10}>
-              <CartesianGrid horizontal={false} strokeDasharray="0 0" stroke={isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'} />
-              <XAxis type="number" domain={[0, (max) => Math.ceil((max || 0) * 1.2)]} allowDecimals={false} tickFormatter={formatMiles} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)' }} />
-              <YAxis type="category" dataKey="direccionGeneral" width={260} tickLine={false} interval={0} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)', fontSize: 12 }} />
-              <Tooltip wrapperStyle={{ outline: 'none' }} content={({ active, payload }) => (
-                <UnifiedTooltip active={active} payload={payload} dark={isDarkMode} label={`Dirección General: ${payload?.[0]?.payload?.direccionGeneral || 'Sin especificar'}`}>
-                  {payload?.length && (
-                    <>
-                      <div>Cantidad de agentes: {formatMiles(payload[0].payload.cantidad)}</div>
-                      <div>Porcentaje: {formatPct((payload[0].payload.cantidad || 0) / (grandTotal || 1))}</div>
-                    </>
-                  )}
-                </UnifiedTooltip>
-              )} />
+            <BarChart
+              data={pageData}
+              layout="vertical"
+              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+              barCategoryGap={10}
+            >
+              <CartesianGrid
+                horizontal={false}
+                strokeDasharray="0 0"
+                stroke={
+                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
+                }
+              />
+              <XAxis
+                type="number"
+                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+                allowDecimals={false}
+                tickFormatter={formatMiles}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                }}
+              />
+              <YAxis
+                type="category"
+                dataKey="direccionGeneral"
+                width={260}
+                tickLine={false}
+                interval={0}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                  fontSize: 12,
+                }}
+              />
+              <Tooltip
+                wrapperStyle={{ outline: "none" }}
+                content={({ active, payload }) => (
+                  <UnifiedTooltip
+                    active={active}
+                    payload={payload}
+                    dark={isDarkMode}
+                    label={`Dirección General: ${payload?.[0]?.payload?.direccionGeneral || "Sin especificar"}`}
+                  >
+                    {payload?.length && (
+                      <>
+                        <div>
+                          Cantidad de agentes:{" "}
+                          {formatMiles(payload[0].payload.cantidad)}
+                        </div>
+                        <div>
+                          Porcentaje:{" "}
+                          {formatPct(
+                            (payload[0].payload.cantidad || 0) /
+                              (grandTotal || 1),
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </UnifiedTooltip>
+                )}
+              />
               <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList dataKey="cantidad" content={(p) => <EndOutsideLabel {...p} />} />
+                <LabelList
+                  dataKey="cantidad"
+                  content={(p) => <EndOutsideLabel {...p} />}
+                />
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </Box>
         {chartData.length > PAGE && (
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
-            <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(168,85,247,0.08)' } }} onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0}>« Anterior</Button>
-            <Typography variant="body2" sx={{ alignSelf: 'center' }}>Página {page + 1} de {totalPages}</Typography>
-            <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(168,85,247,0.08)' } }} onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))} disabled={page === totalPages - 1}>Siguiente »</Button>
+          <Box
+            sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}
+          >
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(168,85,247,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+            >
+              « Anterior
+            </Button>
+            <Typography variant="body2" sx={{ alignSelf: "center" }}>
+              Página {page + 1} de {totalPages}
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(168,85,247,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page === totalPages - 1}
+            >
+              Siguiente »
+            </Button>
           </Box>
         )}
       </CardContent>

--- a/frontend/src/components/AgentsBySubsecretariaBarChart.jsx
+++ b/frontend/src/components/AgentsBySubsecretariaBarChart.jsx
@@ -1,31 +1,57 @@
-import React, { useMemo, useState } from 'react';
-import { Card, CardContent, Typography, Box, Button, Chip } from '@mui/material';
-import AccountTreeIcon from '@mui/icons-material/AccountTree';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LabelList } from 'recharts';
-import { formatMiles, formatPct, UnifiedTooltip } from '../ui/chart-utils';
+import React, { useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Button,
+  Chip,
+} from "@mui/material";
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+} from "recharts";
+import { formatMiles, formatPct, UnifiedTooltip } from "../ui/chart-utils";
 
-const COLOR = '#f59e0b';
+const COLOR = "#f59e0b";
 
 const AgentsBySubsecretariaBarChart = ({ data, isDarkMode }) => {
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
-      subsecretaria: (d.subsecretaria ?? '').toString().trim() || 'Sin especificar',
+      subsecretaria:
+        (d.subsecretaria ?? "").toString().trim() || "Sin especificar",
       cantidad: Number(d.count || 0),
     }));
     return rows.sort((a, b) => b.cantidad - a.cantidad);
   }, [data]);
 
   const [page, setPage] = useState(0);
-  const PAGE = 5;
+  const PAGE = 10;
   const totalPages = Math.ceil((chartData.length || 0) / PAGE) || 1;
-  const pageData = useMemo(() => chartData.slice(page * PAGE, (page + 1) * PAGE), [chartData, page]);
-  const grandTotal = useMemo(() => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0), [chartData]);
+  const pageData = useMemo(
+    () => chartData.slice(page * PAGE, (page + 1) * PAGE),
+    [chartData, page],
+  );
+  const grandTotal = useMemo(
+    () => chartData.reduce((s, d) => s + (Number(d.cantidad) || 0), 0),
+    [chartData],
+  );
 
   const MIN_RIGHT = 140;
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map((d) => `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`);
+    const labels = pageData.map(
+      (d) =>
+        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
@@ -35,52 +61,198 @@ const AgentsBySubsecretariaBarChart = ({ data, isDarkMode }) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
     const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
-    const color = isDarkMode ? '#ffffff' : '#0f172a';
+    const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
-      <text x={x + width + 8} y={y + (height || 0) / 2} fontSize={12} textAnchor="start" dominantBaseline="central" fill={color} fontWeight="600" pointerEvents="none">{label}</text>
+      <text
+        x={x + width + 8}
+        y={y + (height || 0) / 2}
+        fontSize={12}
+        textAnchor="start"
+        dominantBaseline="central"
+        fill={color}
+        fontWeight="600"
+        pointerEvents="none"
+      >
+        {label}
+      </text>
     );
   };
 
   return (
-    <Card sx={{ height: '100%', background: isDarkMode ? 'rgba(45, 55, 72, 0.8)' : 'rgba(255, 255, 255, 0.9)', backdropFilter: 'blur(20px)', border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.08)', borderLeft: `6px solid ${COLOR}`, borderRadius: 3, transition: 'all 0.3s ease', '&:hover': { transform: 'translateY(-4px)', boxShadow: isDarkMode ? '0 12px 40px rgba(0, 0, 0, 0.4)' : '0 12px 40px rgba(0, 0, 0, 0.15)' } }}>
+    <Card
+      sx={{
+        height: "100%",
+        background: isDarkMode
+          ? "rgba(45, 55, 72, 0.8)"
+          : "rgba(255, 255, 255, 0.9)",
+        backdropFilter: "blur(20px)",
+        border: isDarkMode
+          ? "1px solid rgba(255, 255, 255, 0.1)"
+          : "1px solid rgba(0, 0, 0, 0.08)",
+        borderLeft: `6px solid ${COLOR}`,
+        borderRadius: 3,
+        transition: "all 0.3s ease",
+        "&:hover": {
+          transform: "translateY(-4px)",
+          boxShadow: isDarkMode
+            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
+            : "0 12px 40px rgba(0, 0, 0, 0.15)",
+        },
+      }}
+    >
       <CardContent sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25 }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 1.25,
+          }}
+        >
           <AccountTreeIcon sx={{ color: COLOR }} />
-          <Typography variant="h6" align="center" sx={{ fontWeight: 600, color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)' }}>
+          <Typography
+            variant="h6"
+            align="center"
+            sx={{
+              fontWeight: 600,
+              color: isDarkMode
+                ? "rgba(255, 255, 255, 0.9)"
+                : "rgba(0, 0, 0, 0.8)",
+            }}
+          >
             Agentes por Subsecretaría - Planta y Contratos
           </Typography>
-          <Chip label="Subsecretaría" size="small" variant="outlined" sx={{ borderColor: COLOR, color: COLOR }} />
+          <Chip
+            label="Subsecretaría"
+            size="small"
+            variant="outlined"
+            sx={{ borderColor: COLOR, color: COLOR }}
+          />
         </Box>
-        <Typography variant="body2" align="center" sx={{ mb: 2, color: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)' }}>
+        <Typography
+          variant="body2"
+          align="center"
+          sx={{
+            mb: 2,
+            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+          }}
+        >
           {chartData.length} categorías • {formatMiles(grandTotal)} agentes
         </Typography>
         <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={pageData} layout="vertical" margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }} barCategoryGap={10}>
-              <CartesianGrid horizontal={false} strokeDasharray="0 0" stroke={isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'} />
-              <XAxis type="number" domain={[0, (max) => Math.ceil((max || 0) * 1.2)]} allowDecimals={false} tickFormatter={formatMiles} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)' }} />
-              <YAxis type="category" dataKey="subsecretaria" width={240} tickLine={false} interval={0} tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)', fontSize: 12 }} />
-              <Tooltip wrapperStyle={{ outline: 'none' }} content={({ active, payload }) => (
-                <UnifiedTooltip active={active} payload={payload} dark={isDarkMode} label={`Subsecretaría: ${payload?.[0]?.payload?.subsecretaria || 'Sin especificar'}`}>
-                  {payload?.length && (
-                    <>
-                      <div>Cantidad de agentes: {formatMiles(payload[0].payload.cantidad)}</div>
-                      <div>Porcentaje: {formatPct((payload[0].payload.cantidad || 0) / (grandTotal || 1))}</div>
-                    </>
-                  )}
-                </UnifiedTooltip>
-              )} />
+            <BarChart
+              data={pageData}
+              layout="vertical"
+              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+              barCategoryGap={10}
+            >
+              <CartesianGrid
+                horizontal={false}
+                strokeDasharray="0 0"
+                stroke={
+                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
+                }
+              />
+              <XAxis
+                type="number"
+                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+                allowDecimals={false}
+                tickFormatter={formatMiles}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                }}
+              />
+              <YAxis
+                type="category"
+                dataKey="subsecretaria"
+                width={240}
+                tickLine={false}
+                interval={0}
+                tick={{
+                  fill: isDarkMode
+                    ? "rgba(255,255,255,0.7)"
+                    : "rgba(0,0,0,0.7)",
+                  fontSize: 12,
+                }}
+              />
+              <Tooltip
+                wrapperStyle={{ outline: "none" }}
+                content={({ active, payload }) => (
+                  <UnifiedTooltip
+                    active={active}
+                    payload={payload}
+                    dark={isDarkMode}
+                    label={`Subsecretaría: ${payload?.[0]?.payload?.subsecretaria || "Sin especificar"}`}
+                  >
+                    {payload?.length && (
+                      <>
+                        <div>
+                          Cantidad de agentes:{" "}
+                          {formatMiles(payload[0].payload.cantidad)}
+                        </div>
+                        <div>
+                          Porcentaje:{" "}
+                          {formatPct(
+                            (payload[0].payload.cantidad || 0) /
+                              (grandTotal || 1),
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </UnifiedTooltip>
+                )}
+              />
               <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList dataKey="cantidad" content={(p) => <EndOutsideLabel {...p} />} />
+                <LabelList
+                  dataKey="cantidad"
+                  content={(p) => <EndOutsideLabel {...p} />}
+                />
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </Box>
         {chartData.length > PAGE && (
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
-            <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(245,158,11,0.08)' } }} onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0}>« Anterior</Button>
-            <Typography variant="body2" sx={{ alignSelf: 'center' }}>Página {page + 1} de {totalPages}</Typography>
-            <Button variant="outlined" size="small" sx={{ borderColor: COLOR, color: COLOR, '&:hover': { borderColor: COLOR, backgroundColor: 'rgba(245,158,11,0.08)' } }} onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))} disabled={page === totalPages - 1}>Siguiente »</Button>
+          <Box
+            sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}
+          >
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(245,158,11,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+            >
+              « Anterior
+            </Button>
+            <Typography variant="body2" sx={{ alignSelf: "center" }}>
+              Página {page + 1} de {totalPages}
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              sx={{
+                borderColor: COLOR,
+                color: COLOR,
+                "&:hover": {
+                  borderColor: COLOR,
+                  backgroundColor: "rgba(245,158,11,0.08)",
+                },
+              }}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page === totalPages - 1}
+            >
+              Siguiente »
+            </Button>
           </Box>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary
- show more subsecretarías per page
- display additional dependencies, direcciones generales, direcciones and departamentos in bar charts

## Testing
- `npx prettier --write "frontend/src/components/AgentsBy*BarChart.jsx"`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c176bf01508327874dd865f8469867