### PR TITLE
feat: enhance UI theme

### DIFF
--- a/frontend/src/ui/index.js
+++ b/frontend/src/ui/index.js
@@ -1,3 +1,3 @@
-export { default as theme } from './theme.js';
+export { default as theme, modeVars } from './theme.js';
 export { default as icons } from './icons.js';
 export * from './chart-utils';

--- a/frontend/src/ui/theme.js
+++ b/frontend/src/ui/theme.js
@@ -1,14 +1,58 @@
-const theme = {
-  palette: {
-    primary: '#3b82f6',
-    primaryLight: '#60a5fa',
-  },
-  radii: {
-    sm: 4,
-    md: 8,
-    lg: 12,
-  },
-  boxShadow: '0 6px 18px rgba(2,6,23,0.12)',
+const palette = {
+  primary: '#3b82f6',
+  primaryLight: '#60a5fa',
+  backgroundLight: '#ffffff',
+  backgroundDark: '#1e293b',
+  textLight: '#0f172a',
+  textDark: '#f8fafc',
+  hoverLight: '#f1f5f9',
+  hoverDark: '#475569',
 };
 
+const radii = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+};
+
+const shadows = {
+  sm: '0 1px 2px rgba(0,0,0,0.05)',
+  md: '0 4px 6px rgba(0,0,0,0.1)',
+  lg: '0 10px 15px rgba(0,0,0,0.15)',
+};
+
+const typography = {
+  fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+  fontSize: {
+    sm: '0.875rem',
+    md: '1rem',
+    lg: '1.125rem',
+    xl: '1.25rem',
+  },
+};
+
+const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+};
+
+const theme = {
+  palette,
+  radii,
+  shadows,
+  typography,
+  spacing,
+};
+
+export const modeVars = (isDarkMode) => ({
+  '--bg-color': isDarkMode ? palette.backgroundDark : palette.backgroundLight,
+  '--text-color': isDarkMode ? palette.textDark : palette.textLight,
+  '--hover-color': isDarkMode ? palette.hoverDark : palette.hoverLight,
+});
+
+export { theme };
 export default theme;
+


### PR DESCRIPTION
## Summary
- define palette, radii, shadows, typography and spacing
- add modeVars helper for light/dark CSS variables
- export modeVars alongside theme

## Testing
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c1871cb0e88327a2cebe49616619f0