### PR TITLE
feat: add material icons mapping for ui

### DIFF
--- a/frontend/src/ui/icons.js
+++ b/frontend/src/ui/icons.js
@@ -1,9 +1,24 @@
+import {
+  Group as GroupIcon,
+  Cake as CakeIcon,
+  Schema as SchemaIcon,
+  Summarize as SummarizeIcon,
+  History as HistoryIcon,
+  Assignment as AssignmentIcon,
+  Percent as PercentIcon,
+  AttachMoney as AttachMoneyIcon
+} from '@mui/icons-material';
+
 const icons = {
-  edad: 'cake',
-  personas: 'group',
-  agentes: 'badge',
-  salario: 'attach_money',
-  eficiencia: 'trending_up',
+  personas: GroupIcon,
+  edad: CakeIcon,
+  distribucion: SchemaIcon,
+  resumen: SummarizeIcon,
+  antiguedad: HistoryIcon,
+  contratos: AssignmentIcon,
+  porcentaje: PercentIcon,
+  money: AttachMoneyIcon
 };
 
 export default icons;
+


### PR DESCRIPTION
## Summary
- import Material icons
- map UI icon names to Material icon components

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c187eba5f483278504b33ca65393da