### PR TITLE
feat: add recharts common utilities

### DIFF
--- a/frontend/src/ui/chart-utils.tsx
+++ b/frontend/src/ui/chart-utils.tsx
@@ -1,21 +1,28 @@
 import React from "react";
 
 /**
- * Utilidades de formato y estilo para los componentes de gráficos.
+ * Utilidades de formato y estilo para gráficos construidos con Recharts.
  *
- * `axisStyle(dark)`, `gridStyle(dark)` y `tooltipStyle(dark)` retornan
- * objetos con los colores y tipografías estándar según el modo oscuro o
- * claro.  Se pueden usar en los componentes de Recharts para mantener
- * una apariencia consistente:
+ * La función `rechartsCommon()` provee estilos y colores estandarizados
+ * para ejes, grillas y tooltips dependiendo del modo oscuro/claro. Estos
+ * valores se pueden utilizar directamente en los componentes de Recharts
+ * para mantener una apariencia coherente:
  *
- *   <XAxis {...axisStyle()} />
- *   <CartesianGrid {...gridStyle()} />
- *   <Tooltip wrapperStyle={tooltipStyle()} content={<UnifiedTooltip />} />
+ * ```tsx
+ * const { axisProps, gridProps, tooltipProps } = rechartsCommon();
+ * <XAxis {...axisProps} />
+ * <CartesianGrid {...gridProps} />
+ * <Tooltip {...tooltipProps} content={<UnifiedTooltip />} />
+ * ```
  */
 
 export const nf = new Intl.NumberFormat("es-AR");
-export const formatMiles = (n: number) => nf.format(n);
-export const formatPct = (p: number, d = 1) =>
+
+/** Formatea números con separador de miles. */
+const formatMiles = (n: number): string => nf.format(n);
+
+/** Formatea porcentajes con `d` decimales. */
+const formatPct = (p: number, d = 1): string =>
   `${(p * 100).toFixed(d).replace(".", ",")}%`;
 
 export const isDark = () =>
@@ -64,6 +71,34 @@ export const tooltipStyle = (dark?: boolean) => {
     minWidth: 220,
     fontSize: 14,
   } as React.CSSProperties;
+};
+
+/**
+ * Propiedades comunes para Recharts y paleta de colores derivada.
+ */
+const rechartsCommon = (dark?: boolean): {
+  axisProps: ReturnType<typeof axisStyle>;
+  gridProps: ReturnType<typeof gridStyle>;
+  tooltipProps: { wrapperStyle: React.CSSProperties };
+  colors: {
+    tick: string;
+    axisLine: string;
+    grid: string;
+    tooltipBg: string;
+    tooltipText: string;
+  };
+} => {
+  const axisProps = axisStyle(dark);
+  const gridProps = gridStyle(dark);
+  const tooltipProps = { wrapperStyle: tooltipStyle(dark) };
+  const colors = {
+    tick: axisProps.tick.fill as string,
+    axisLine: axisProps.axisLine.stroke as string,
+    grid: gridProps.stroke as string,
+    tooltipBg: tooltipProps.wrapperStyle.background as string,
+    tooltipText: tooltipProps.wrapperStyle.color as string,
+  };
+  return { axisProps, gridProps, tooltipProps, colors };
 };
 
 const RIGHT_PAD = 8;
@@ -133,3 +168,5 @@ export const UnifiedTooltip: React.FC<{
     </div>
   );
 };
+
+export { formatMiles, formatPct, rechartsCommon };


### PR DESCRIPTION
### **User description**
## Summary
- centralize recharts style handling via `rechartsCommon`
- re-export formatting helpers for miles and percentages

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1897ffec08327aea080c502b2b349


___

### **PR Type**
Enhancement


___

### **Description**
- Add centralized `rechartsCommon()` utility for consistent chart styling

- Re-export formatting helpers `formatMiles` and `formatPct`

- Improve documentation with usage examples

- Extract color palette from chart styling functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Individual Style Functions"] --> B["rechartsCommon()"]
  B --> C["Unified Chart Props"]
  B --> D["Color Palette"]
  E["Format Functions"] --> F["Re-exported Helpers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chart-utils.tsx</strong><dd><code>Centralize recharts styling and export formatters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/ui/chart-utils.tsx

<ul><li>Add <code>rechartsCommon()</code> function that consolidates axis, grid, and <br>tooltip styling<br> <li> Re-export <code>formatMiles</code> and <code>formatPct</code> formatting functions<br> <li> Extract color palette from existing styling functions<br> <li> Update documentation with clearer usage examples</ul>


</details>


  </td>
  <td><a href="https://github.com/CarlosJFer/AnalisisDeDotacion/pull/120/files#diff-3a2b0293581a4875e806e76437ecd08ef0093f27e791b6f2836e397b1450715b">+47/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

