### PR TITLE
refactor: modernize AverageAgeByFunctionChart

### DIFF
--- a/frontend/src/components/AverageAgeByFunctionChart.jsx
+++ b/frontend/src/components/AverageAgeByFunctionChart.jsx
@@ -1,6 +1,5 @@
-import React, { useMemo, useState } from 'react';
-import { Card, CardContent, Typography, Box, Chip } from '@mui/material';
-import QueryStatsIcon from '@mui/icons-material/QueryStats';
+import React, { useMemo, useState, useCallback } from 'react';
+import { Typography, Box, Chip } from '@mui/material';
 import {
   BarChart,
   Bar,
@@ -11,13 +10,22 @@ import {
   ResponsiveContainer,
   LabelList,
 } from 'recharts';
-import { formatMiles, formatPct, UnifiedTooltip } from '../ui/chart-utils';
+import {
+  formatMiles,
+  formatPct,
+  rechartsCommon,
+  UnifiedTooltip,
+  AvgAgeLabel,
+} from '../ui/chart-utils';
 import PaginationControls from './ui/PaginationControls.jsx';
-
-const MARGIN_RIGHT = 120;
-const COLOR = '#10b981';
+import DashboardCard from './ui/DashboardCard.jsx';
+import icons from '../ui/icons.js';
+import { useTheme } from '../context/ThemeContext.jsx';
 
 const AverageAgeByFunctionChart = ({ data, isDarkMode }) => {
+  const { theme } = useTheme();
+  const COLOR = theme.palette.primary.main;
+  const { axisProps, gridProps, tooltipProps } = rechartsCommon(isDarkMode);
   const chartData = useMemo(
     () =>
       data
@@ -33,7 +41,7 @@ const AverageAgeByFunctionChart = ({ data, isDarkMode }) => {
 
   const [page, setPage] = useState(0);
   const PAGE = 10;
-  const totalPages = Math.ceil(chartData.length / PAGE);
+  const totalPages = Math.ceil(chartData.length / PAGE) || 1;
   const pageData = useMemo(
     () => chartData.slice(page * PAGE, (page + 1) * PAGE),
     [chartData, page]
@@ -60,149 +68,107 @@ const AverageAgeByFunctionChart = ({ data, isDarkMode }) => {
   // Margen derecho dinámico en base al largo de las etiquetas fuera de la barra
   const MIN_RIGHT = 160;
   const MAX_RIGHT = 260;
-  const dynamicRight = React.useMemo(() => {
+  const dynamicRight = useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map((d) => {
-      const avg = Math.round(Number(d.avg || d.promedio || 0));
-      const cnt = Number(d.cantidad || 0);
-      return `${avg} años — ${formatMiles(cnt)} (${formatPct((cnt || 0) / (grandTotal || 1))})`;
-    });
-    const maxChars = Math.max(...labels.map((t) => t.length));
-    const approxWidth = maxChars * 7 + 20; // 7px por carácter + padding
-    return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
-  }, [pageData, grandTotal]);
-
-  // Etiqueta personalizada: afuera a la derecha, combinando promedio + cantidad
-  const EndOutsideLabel = (props) => {
-    const { x = 0, y = 0, width = 0, height = 0, value = 0, index = 0 } = props;
-    const row = pageData?.[index] || {};
-    const avg = Math.round(Number((row.avg ?? row.promedio ?? value ?? 0)));
-    const cnt = Number(row.cantidad ?? 0);
-    const label = `${avg} años — ${formatMiles(cnt)} (${formatPct((cnt || 0) / (grandTotal || 1))})`;
-    const xText = x + width + 8;
-    const yText = y + (height || 0) / 2;
-    const color = isDarkMode ? '#ffffff' : '#0f172a';
-    return (
-      <text
-        x={xText}
-        y={yText}
-        fontSize={12}
-        textAnchor="start"
-        dominantBaseline="central"
-        fill={color}
-        fontWeight="600"
-        pointerEvents="none"
-      >
-        {label}
-      </text>
+    const maxAvg = Math.max(
+      ...pageData.map((d) => Math.round(Number(d.avg ?? d.promedio ?? 0)))
     );
-  };
+    const label = `Edad promedio: ${maxAvg} años`;
+    const approxWidth = label.length * 7 + 20;
+    return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
+  }, [pageData]);
+
+  const handlePrev = useCallback(
+    () => setPage((p) => Math.max(0, p - 1)),
+    []
+  );
+  const handleNext = useCallback(
+    () => setPage((p) => Math.min(totalPages - 1, p + 1)),
+    [totalPages]
+  );
 
   return (
-    <Card
-      sx={{
-        height: '100%',
-        background: isDarkMode ? 'rgba(45, 55, 72, 0.8)' : 'rgba(255, 255, 255, 0.9)',
-        backdropFilter: 'blur(20px)',
-        border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.08)',
-        borderLeft: `6px solid ${COLOR}`,
-        borderRadius: 3,
-        transition: 'all 0.3s ease',
-        '&:hover': {
-          transform: 'translateY(-4px)',
-          boxShadow: isDarkMode
-            ? '0 12px 40px rgba(0, 0, 0, 0.4)'
-            : '0 12px 40px rgba(0, 0, 0, 0.15)',
-        },
-      }}
+    <DashboardCard
+      title="Edad Promedio por Función - Planta y Contratos"
+      icon={<icons.edad />}
+      isDarkMode={isDarkMode}
+      headerRight={
+        <Chip
+          label="Análisis de Edad"
+          size="small"
+          variant="outlined"
+          sx={{ borderColor: COLOR, color: COLOR }}
+        />
+      }
     >
-      <CardContent sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25, mb: 2 }}>
-          <QueryStatsIcon sx={{ color: COLOR }} />
-          <Typography
-            variant="h6"
-            sx={{
-              fontWeight: 600,
-              color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-            }}
+      <Typography
+        variant="body2"
+        align="center"
+        sx={{ mb: 2, color: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)' }}
+      >
+        {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      </Typography>
+      <Box sx={{ height: Math.max(420, pageData.length * 30) }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
           >
-            Edad Promedio por Función - Planta y Contratos
-          </Typography>
-          <Chip label="Análisis de Edad" size="small" variant="outlined" sx={{ borderColor: COLOR, color: COLOR }} />
-        </Box>
-        <Typography
-          variant="body2"
-          align="center"
-          sx={{
-            mb: 2,
-            color: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)',
-          }}
-        >
-          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
-        </Typography>
-        <Box sx={{ height: Math.max(420, pageData.length * 30) }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={pageData}
-              layout="vertical"
-              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
-              barCategoryGap={10}
-            >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}
-              />
-              <XAxis
-                type="number"
-                domain={[0, (max) => Math.ceil(max * 1.2)]}
-                allowDecimals={false}
-                ticks={xTicks}
-                tickFormatter={formatMiles}
-                tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)' }}
-              />
-              <YAxis
-                type="category"
-                dataKey="funcion"
-                width={240}
-                tickLine={false}
-                interval={0}
-                tick={{ fill: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.7)', fontSize: 12 }}
-              />
-              <Tooltip
-                wrapperStyle={{ outline: 'none' }}
-                content={({ active, payload }) => (
-                  <UnifiedTooltip
-                    active={active}
-                    payload={payload} dark={isDarkMode}
-                    label={`Función: ${payload?.[0]?.payload?.funcion || 'Sin función'}`}
-                  >
-                    {payload?.length && (
-                      <>
-                        <div>Edad promedio: {Math.round(payload[0].payload.avg)} años</div>
-                        <div>Cantidad de agentes: {formatMiles(payload[0].payload.cantidad)}</div>
-                        <div>Porcentaje: {formatPct(payload[0].payload.cantidad / (grandTotal || 1))}</div>
-                      </>
-                    )}
-                  </UnifiedTooltip>
-                )}
-              />
-              <Bar dataKey="avg" maxBarSize={22} fill={isDarkMode ? '#10b981' : '#059669'}>
-                <LabelList dataKey="avg" content={(props) => <EndOutsideLabel {...props} />} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {chartData.length > PAGE && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages}
-            onPrev={() => setPage((p) => Math.max(0, p - 1))}
-            onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-          />
-        )}
-      </CardContent>
-    </Card>
+            <CartesianGrid {...gridProps} horizontal={false} strokeDasharray="0 0" />
+            <XAxis
+              {...axisProps}
+              type="number"
+              domain={[0, (max) => Math.ceil(max * 1.2)]}
+              allowDecimals={false}
+              ticks={xTicks}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisProps}
+              type="category"
+              dataKey="funcion"
+              width={240}
+              tickLine={false}
+              interval={0}
+            />
+            <Tooltip
+              {...tooltipProps}
+              content={({ active, payload }) => (
+                <UnifiedTooltip
+                  active={active}
+                  payload={payload}
+                  label={`Función: ${payload?.[0]?.payload?.funcion || 'Sin función'}`}
+                  dark={isDarkMode}
+                >
+                  {payload?.length && (
+                    <>
+                      <div>Edad promedio: {Math.round(payload[0].payload.avg)} años</div>
+                      <div>Cantidad de agentes: {formatMiles(payload[0].payload.cantidad)}</div>
+                      <div>
+                        Porcentaje: {formatPct(payload[0].payload.cantidad / (grandTotal || 1))}
+                      </div>
+                    </>
+                  )}
+                </UnifiedTooltip>
+              )}
+            />
+            <Bar dataKey="avg" maxBarSize={22} fill={COLOR}>
+              <LabelList dataKey="avg" content={(p) => <AvgAgeLabel {...p} />} />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {chartData.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPrev={handlePrev}
+          onNext={handleNext}
+        />
+      )}
+    </DashboardCard>
   );
 };
 


### PR DESCRIPTION
## Summary
- use `DashboardCard` with theme-based styling in average age chart
- apply `rechartsCommon` + `AvgAgeLabel` and memoized pagination

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c19076f264832783fea0edcc29890d