### PR TITLE
Improve chart accessibility and contrast

### DIFF
--- a/frontend/src/components/CustomBarChart.jsx
+++ b/frontend/src/components/CustomBarChart.jsx
@@ -4,46 +4,65 @@ import AnalyticsIcon from '@mui/icons-material/Analytics';
 import SchoolIcon from '@mui/icons-material/School';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+} from 'recharts';
+import { useTheme } from '../context/ThemeContext.jsx';
 
 // Función para determinar el color, icono y chip basado en el título
-const getChartConfig = (title) => {
-    if (title.includes('Edad') || title.includes('edad')) {
-        return {
-            color: '#00C49F',
-            icon: AnalyticsIcon,
-            chipLabel: 'Análisis de Edad'
-        };
-    } else if (title.includes('Antigüedad') || title.includes('estudios') || title.includes('Secretarías')) {
-        return {
-            color: '#8b5cf6',
-            icon: SchoolIcon,
-            chipLabel: 'Antigüedad y Estudios'
-        };
-    } else if (title.includes('certificaciones') || title.includes('registración') || title.includes('horario')) {
-        return {
-            color: '#f59e0b',
-            icon: AssignmentTurnedInIcon,
-            chipLabel: 'Control de Certificaciones'
-        };
-    } else if (title.includes('expedientes') || title.includes('trámite')) {
-        return {
-            color: '#ef4444',
-            icon: FolderOpenIcon,
-            chipLabel: 'Expedientes'
-        };
-    } else {
-        return {
-            color: '#00C49F',
-            icon: AnalyticsIcon,
-            chipLabel: 'Análisis General'
-        };
-    }
+const getChartConfig = (title, theme) => {
+  if (title.includes('Edad') || title.includes('edad')) {
+    return {
+      color: theme.palette.success.main,
+      icon: AnalyticsIcon,
+      chipLabel: 'Análisis de Edad',
+    };
+  } else if (
+    title.includes('Antigüedad') ||
+    title.includes('estudios') ||
+    title.includes('Secretarías')
+  ) {
+    return {
+      color: theme.palette.secondary.main,
+      icon: SchoolIcon,
+      chipLabel: 'Antigüedad y Estudios',
+    };
+  } else if (
+    title.includes('certificaciones') ||
+    title.includes('registración') ||
+    title.includes('horario')
+  ) {
+    return {
+      color: theme.palette.warning.main,
+      icon: AssignmentTurnedInIcon,
+      chipLabel: 'Control de Certificaciones',
+    };
+  } else if (title.includes('expedientes') || title.includes('trámite')) {
+    return {
+      color: theme.palette.error.main,
+      icon: FolderOpenIcon,
+      chipLabel: 'Expedientes',
+    };
+  } else {
+    return {
+      color: theme.palette.primary.main,
+      icon: AnalyticsIcon,
+      chipLabel: 'Análisis General',
+    };
+  }
 };
 
 const CustomBarChart = React.memo(({ data, xKey, barKey, title, isDarkMode, height = 300 }) => {
+    const { theme } = useTheme();
     const chartData = useMemo(() => data, [data]);
-    const config = getChartConfig(title);
+    const config = useMemo(() => getChartConfig(title, theme), [title, theme]);
     const IconComponent = config.icon;
     
     return (
@@ -68,12 +87,12 @@ const CustomBarChart = React.memo(({ data, xKey, barKey, title, isDarkMode, heig
         }}>
             <CardContent sx={{ p: 3 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25, mb: 2 }}>
-                    <IconComponent sx={{ color: config.color }} />
+                      <IconComponent aria-hidden="true" sx={{ color: config.color }} />
                     <Typography
                         variant="h6"
                         sx={{
                             fontWeight: 600,
-                            color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+                              color: theme.palette.text.primary,
                         }}
                     >
                         {title}
@@ -86,44 +105,40 @@ const CustomBarChart = React.memo(({ data, xKey, barKey, title, isDarkMode, heig
                     />
                 </Box>
                 <Box sx={{ height: height }}>
-                    <ResponsiveContainer width="100%" height="100%">
-                        <BarChart data={chartData} margin={{ top: 5, right: 20, left: -10, bottom: xKey === 'range' ? 40 : 80 }}>
-                            <CartesianGrid
-                                strokeDasharray="3 3"
-                                stroke={isDarkMode ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)'}
-                            />
-                            <XAxis
-                                dataKey={xKey}
-                                tick={{
-                                    fill: isDarkMode ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)',
-                                    fontSize: xKey === 'range' ? 14 : 10
-                                }}
-                                axisLine={{ stroke: isDarkMode ? 'rgba(255, 255, 255, 0.3)' : 'rgba(0, 0, 0, 0.3)' }}
-                                angle={xKey === 'range' ? 0 : -45}
-                                textAnchor={xKey === 'range' ? 'middle' : 'end'}
-                                height={80}
-                                interval={0}
-                            />
-                            <YAxis
-                                tick={{ fill: isDarkMode ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)' }}
-                                axisLine={{ stroke: isDarkMode ? 'rgba(255, 255, 255, 0.3)' : 'rgba(0, 0, 0, 0.3)' }}
-                            />
-                            <Tooltip
-                                contentStyle={{
-                                    backgroundColor: isDarkMode ? 'rgba(45, 55, 72, 0.95)' : 'rgba(255, 255, 255, 0.95)',
-                                    border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.1)',
-                                    borderRadius: '8px',
-                                    color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-                                }}
-                                labelFormatter={(label) => `${xKey === 'function' ? 'Función' : xKey === 'range' ? 'Rango de edad' : xKey === 'area' ? 'Área' : 'Categoría'}: ${label}`}
-                                formatter={(value, name) => [
-                                    barKey === 'avgAge' ? `${Math.round(value)} años` : value,
-                                    barKey === 'avgAge' ? 'Edad promedio' : 'Cantidad de agentes'
-                                ]}
-                            />
-                            <Bar dataKey={barKey} fill={config.color} radius={[4, 4, 0, 0]} />
-                        </BarChart>
-                    </ResponsiveContainer>
+                      <ResponsiveContainer width="100%" height="100%">
+                          <BarChart data={chartData} margin={{ top: 5, right: 20, left: -10, bottom: xKey === 'range' ? 40 : 80 }}>
+                              <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.divider} />
+                              <XAxis
+                                  dataKey={xKey}
+                                  tick={{ fill: theme.palette.text.secondary, fontSize: xKey === 'range' ? 14 : 10 }}
+                                  axisLine={{ stroke: theme.palette.divider }}
+                                  angle={xKey === 'range' ? 0 : -45}
+                                  textAnchor={xKey === 'range' ? 'middle' : 'end'}
+                                  height={80}
+                                  interval={0}
+                              />
+                              <YAxis
+                                  tick={{ fill: theme.palette.text.secondary }}
+                                  axisLine={{ stroke: theme.palette.divider }}
+                              />
+                              <Tooltip
+                                  contentStyle={{
+                                      backgroundColor: theme.palette.background.paper,
+                                      border: `1px solid ${theme.palette.divider}`,
+                                      borderRadius: '8px',
+                                      color: theme.palette.text.primary,
+                                  }}
+                                  labelFormatter={(label) => `${xKey === 'function' ? 'Función' : xKey === 'range' ? 'Rango de edad' : xKey === 'area' ? 'Área' : 'Categoría'}: ${label}`}
+                                  formatter={(value) => [
+                                      barKey === 'avgAge' ? `${Math.round(value)} años` : value,
+                                      barKey === 'avgAge' ? 'Edad promedio' : 'Cantidad de agentes',
+                                  ]}
+                              />
+                              <Bar dataKey={barKey} fill={config.color} radius={[4, 4, 0, 0]}>
+                                  <LabelList dataKey={barKey} position="top" fill={theme.palette.text.primary} />
+                              </Bar>
+                          </BarChart>
+                      </ResponsiveContainer>
                 </Box>
             </CardContent>
         </Card>

--- a/frontend/src/components/CustomDonutChart.jsx
+++ b/frontend/src/components/CustomDonutChart.jsx
@@ -5,38 +5,37 @@ import SchoolIcon from '@mui/icons-material/School';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8', '#82CA9D', '#FFC658', '#FF7C7C', '#8DD1E1', '#D084D0'];
+import { useTheme } from '../context/ThemeContext.jsx';
 
 // Función para determinar el color, icono y chip basado en el título
-const getChartConfig = (title) => {
+const getChartConfig = (title, theme) => {
     if (title.includes('Edad') || title.includes('edad')) {
         return {
-            color: '#00C49F',
+            color: theme.palette.success.main,
             icon: AnalyticsIcon,
             chipLabel: 'Análisis de Edad'
         };
     } else if (title.includes('estudios') || title.includes('título') || title.includes('Secretarías')) {
         return {
-            color: '#8b5cf6',
+            color: theme.palette.secondary.main,
             icon: SchoolIcon,
             chipLabel: 'Antigüedad y Estudios'
         };
     } else if (title.includes('horario') || title.includes('entrada') || title.includes('salida')) {
         return {
-            color: '#f59e0b',
+            color: theme.palette.warning.main,
             icon: AssignmentTurnedInIcon,
             chipLabel: 'Control de Certificaciones'
         };
     } else if (title.includes('expedientes') || title.includes('trámite')) {
         return {
-            color: '#ef4444',
+            color: theme.palette.error.main,
             icon: FolderOpenIcon,
             chipLabel: 'Expedientes'
         };
     } else {
         return {
-            color: '#00C49F',
+            color: theme.palette.primary.main,
             icon: AnalyticsIcon,
             chipLabel: 'Análisis General'
         };
@@ -44,9 +43,22 @@ const getChartConfig = (title) => {
 };
 
 const CustomDonutChart = React.memo(({ data, title, isDarkMode, dataKey, nameKey, height = 400 }) => {
+    const { theme } = useTheme();
     const chartData = useMemo(() => data, [data]);
-    const config = getChartConfig(title);
+    const config = useMemo(() => getChartConfig(title, theme), [title, theme]);
     const IconComponent = config.icon;
+    const COLORS = [
+        theme.palette.primary.main,
+        theme.palette.success.main,
+        theme.palette.warning.main,
+        theme.palette.error.main,
+        theme.palette.secondary.main,
+        theme.palette.info.main,
+        theme.palette.success.light,
+        theme.palette.warning.light,
+        theme.palette.error.light,
+        theme.palette.info.light,
+    ];
 
     const total = useMemo(() => {
         return chartData.reduce((sum, item) => sum + (item[dataKey] || 0), 0);
@@ -58,11 +70,11 @@ const CustomDonutChart = React.memo(({ data, title, isDarkMode, dataKey, nameKey
             const percentage = total > 0 ? ((data[dataKey] / total) * 100).toFixed(1) : 0;
             return (
                 <Box sx={{
-                    backgroundColor: isDarkMode ? 'rgba(45, 55, 72, 0.95)' : 'rgba(255, 255, 255, 0.95)',
-                    border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.1)' : '1px solid rgba(0, 0, 0, 0.1)',
+                    backgroundColor: theme.palette.background.paper,
+                    border: `1px solid ${theme.palette.divider}`,
                     borderRadius: '8px',
                     p: 2,
-                    color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+                    color: theme.palette.text.primary,
                 }}>
                     <Typography variant="body2" sx={{ fontWeight: 600 }}>
                         {data[nameKey]}
@@ -79,7 +91,7 @@ const CustomDonutChart = React.memo(({ data, title, isDarkMode, dataKey, nameKey
         return null;
     };
 
-    const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }) => {
+    const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent, value }) => {
         if (percent < 0.05) return null;
 
         const RADIAN = Math.PI / 180;
@@ -91,13 +103,13 @@ const CustomDonutChart = React.memo(({ data, title, isDarkMode, dataKey, nameKey
             <text
                 x={x}
                 y={y}
-                fill={isDarkMode ? 'white' : 'black'}
+                fill={theme.palette.text.primary}
                 textAnchor={x > cx ? 'start' : 'end'}
                 dominantBaseline="central"
                 fontSize="12"
                 fontWeight="600"
             >
-                {`${(percent * 100).toFixed(0)}%`}
+                {`${value} (${(percent * 100).toFixed(0)}%)`}
             </text>
         );
     };
@@ -124,21 +136,21 @@ const CustomDonutChart = React.memo(({ data, title, isDarkMode, dataKey, nameKey
         }}>
             <CardContent sx={{ p: 3, height: '100%', display: 'flex', flexDirection: 'column' }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25, mb: 2 }}>
-                    <IconComponent sx={{ color: config.color }} />
+                    <IconComponent aria-hidden="true" sx={{ color: config.color }} />
                     <Typography
                         variant="h6"
                         sx={{
                             fontWeight: 600,
-                            color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+                            color: theme.palette.text.primary,
                         }}
                     >
                         {title}
                     </Typography>
-                    <Chip 
-                        label={config.chipLabel} 
-                        size="small" 
-                        variant="outlined" 
-                        sx={{ borderColor: config.color, color: config.color }} 
+                    <Chip
+                        label={config.chipLabel}
+                        size="small"
+                        variant="outlined"
+                        sx={{ borderColor: config.color, color: config.color }}
                     />
                 </Box>
                 <Box sx={{ flexGrow: 1, minHeight: 300 }}>
@@ -152,7 +164,7 @@ const CustomDonutChart = React.memo(({ data, title, isDarkMode, dataKey, nameKey
                                 label={renderCustomizedLabel}
                                 outerRadius={100}
                                 innerRadius={60}
-                                fill="#8884d8"
+                                fill={theme.palette.primary.main}
                                 dataKey={dataKey}
                                 nameKey={nameKey}
                             >
@@ -163,7 +175,7 @@ const CustomDonutChart = React.memo(({ data, title, isDarkMode, dataKey, nameKey
                             <Tooltip content={<CustomTooltip />} />
                             <Legend
                                 wrapperStyle={{
-                                    color: isDarkMode ? 'rgba(255, 255, 255, 0.8)' : 'rgba(0, 0, 0, 0.7)',
+                                    color: theme.palette.text.secondary,
                                     fontSize: '12px',
                                     paddingTop: '10px'
                                 }}

--- a/frontend/src/components/CustomHorizontalBarChart.jsx
+++ b/frontend/src/components/CustomHorizontalBarChart.jsx
@@ -12,6 +12,7 @@ import {
   LabelList,
 } from 'recharts';
 import PaginationControls from './ui/PaginationControls.jsx';
+import { useTheme } from '../context/ThemeContext.jsx';
 
 const nf = new Intl.NumberFormat('es-AR');
 const formatMiles = (n) => nf.format(n);
@@ -24,7 +25,6 @@ const truncate = (text, max = 30) => {
 
 const RIGHT_PAD = 8;
 const MARGIN_RIGHT = 96;
-const COLOR = '#00C49F';
 
 const formatShort = (n) => {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace('.', ',') + 'M';
@@ -41,6 +41,8 @@ const CustomHorizontalBarChart = ({
   height,
   pageSize,
 }) => {
+  const { theme } = useTheme();
+  const COLOR = theme.palette.primary.main;
   const chartData = useMemo(
     () =>
       data
@@ -81,7 +83,7 @@ const CustomHorizontalBarChart = ({
             y={0}
             dy={4}
             textAnchor="end"
-            fill={isDarkMode ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)'}
+            fill={theme.palette.text.secondary}
             fontSize={12}
           >
             {truncated}
@@ -103,7 +105,7 @@ const CustomHorizontalBarChart = ({
     }
 
     const textX = barEndX + RIGHT_PAD;
-    const fill = isDarkMode ? '#ffffff' : '#0f172a';
+    const fill = theme.palette.text.primary;
 
     return (
       <text
@@ -123,9 +125,9 @@ const CustomHorizontalBarChart = ({
   const CustomTooltip = ({ active, payload, label }) => {
     if (!active || !payload || !payload.length) return null;
     const v = payload[0]?.value || 0;
-    const bg = isDarkMode ? '#0b1220' : '#ffffff';
-    const fg = isDarkMode ? '#e2e8f0' : '#0f172a';
-    const bd = isDarkMode ? '#334155' : '#cbd5e1';
+    const bg = theme.palette.background.paper;
+    const fg = theme.palette.text.primary;
+    const bd = theme.palette.divider;
     return (
       <div
         style={{
@@ -169,12 +171,12 @@ const CustomHorizontalBarChart = ({
     >
       <CardContent sx={{ p: 3 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.25, mb: 2 }}>
-          <DashboardIcon sx={{ color: COLOR }} />
+          <DashboardIcon aria-hidden="true" sx={{ color: COLOR }} />
           <Typography
             variant="h6"
             sx={{
               fontWeight: 600,
-              color: isDarkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+              color: theme.palette.text.primary,
             }}
           >
             {title}
@@ -186,7 +188,7 @@ const CustomHorizontalBarChart = ({
           align="center"
           sx={{
             mb: 2,
-            color: isDarkMode ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)',
+            color: theme.palette.text.secondary,
           }}
         >
           {chartData.length} categorías • {formatMiles(total)} agentes
@@ -199,18 +201,18 @@ const CustomHorizontalBarChart = ({
               margin={{ top: 16, right: MARGIN_RIGHT, bottom: 16, left: 240 }}
               barCategoryGap={10}
             >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}
-              />
-              <XAxis
-                type="number"
-                domain={[0, (dataMax) => Math.ceil(dataMax * 1.2)]}
-                tickFormatter={formatMiles}
-                allowDecimals={false}
-                tick={{ fill: isDarkMode ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)' }}
-              />
+                <CartesianGrid
+                  horizontal={false}
+                  strokeDasharray="0 0"
+                  stroke={theme.palette.divider}
+                />
+                <XAxis
+                  type="number"
+                  domain={[0, (dataMax) => Math.ceil(dataMax * 1.2)]}
+                  tickFormatter={formatMiles}
+                  allowDecimals={false}
+                  tick={{ fill: theme.palette.text.secondary }}
+                />
               <YAxis
                 type="category"
                 dataKey={nameKey}
@@ -224,9 +226,9 @@ const CustomHorizontalBarChart = ({
                 cursor={{ fill: 'rgba(255,255,255,0.04)' }}
                 wrapperStyle={{ outline: 'none' }}
               />
-              <Bar dataKey={valueKey} maxBarSize={22} fill="#00C49F">
-                <LabelList content={<ValueLabel />} />
-              </Bar>
+                <Bar dataKey={valueKey} maxBarSize={22} fill={COLOR}>
+                  <LabelList content={<ValueLabel />} />
+                </Bar>
             </BarChart>
           </ResponsiveContainer>
         </Box>


### PR DESCRIPTION
## Summary
- use theme palette for chart colors and add hidden icons
- expose bar and pie values with visible labels instead of relying on tooltips
- adjust pagination controls with aria labels (already present) and ensure high-contrast text

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68c1965ae43c83279b27bb0b80a07e20