### PR TITLE
feat: support react navigation on auth error

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2,6 +2,13 @@
 
 import axios from "axios";
 
+// Navigator helper that can be injected from React components
+let navigator;
+
+export const setNavigate = (nav) => {
+  navigator = nav;
+};
+
 // 1. Creamos una instancia de Axios con la URL base de nuestro backend.
 const apiClient = axios.create({
   baseURL: "http://localhost:5001/api", // La base de todas tus rutas de la API
@@ -58,7 +65,11 @@ apiClient.interceptors.response.use(
     } else if (error.response?.status === 401) {
       console.warn("Unauthorized access - redirecting to login");
       localStorage.removeItem("userInfo");
-      window.location.href = "/login";
+      if (navigator) {
+        navigator("/login", { replace: true });
+      } else {
+        window.location.href = "/login";
+      }
     } else if (error.response?.status >= 500) {
       console.error("Server error:", error.response.status);
     }


### PR DESCRIPTION
## Summary
- allow injecting a React Router navigator via `setNavigate`
- use provided navigator to redirect to `/login` on unauthorized responses

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1c0ef4de483279f0b46fc0618cc6e