### PR TITLE
feat: use navigate in error fallback

### DIFF
--- a/frontend/src/components/ErrorFallback.jsx
+++ b/frontend/src/components/ErrorFallback.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
   Card,
@@ -20,6 +21,7 @@ import {
 } from "@mui/icons-material";
 
 const ErrorFallback = ({ error, resetErrorBoundary }) => {
+  const navigate = useNavigate();
   const handleReportError = () => {
     // Aquí se podría enviar el error a un servicio de logging
     console.error("Error reportado:", error);
@@ -40,7 +42,7 @@ const ErrorFallback = ({ error, resetErrorBoundary }) => {
   };
 
   const handleGoHome = () => {
-    window.location.href = "/";
+    navigate("/", { replace: true });
   };
 
   return (


### PR DESCRIPTION
## Summary
- use `useNavigate` from react-router to replace manual href in `ErrorFallback`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1c1989c2c83278eb623e3e5c0b5fc