### PR TITLE
refactor: move error boundary inside router

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -140,10 +140,10 @@ const AppLayout = () => {
 
 function App() {
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
-      <HelmetProvider>
-        <QueryClientProvider client={queryClient}>
-          <Router>
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
             <CustomThemeProvider>
               <AuthProvider>
                 <NotificationProvider>
@@ -153,10 +153,10 @@ function App() {
                 </NotificationProvider>
               </AuthProvider>
             </CustomThemeProvider>
-          </Router>
-        </QueryClientProvider>
-      </HelmetProvider>
-    </ErrorBoundary>
+          </ErrorBoundary>
+        </Router>
+      </QueryClientProvider>
+    </HelmetProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- relocate ErrorBoundary inside Router so routing context wraps error handling

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c3318b908327b037006cad88f442