### PR TITLE
Use injected navigate for login redirect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,16 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useEffect } from "react";
 import {
   BrowserRouter as Router,
   Routes,
   Route,
   Navigate,
   useLocation,
+  useNavigate,
 } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ErrorBoundary } from "react-error-boundary";
 import { HelmetProvider } from "react-helmet-async";
+import { setNavigate } from "./services/api.js";
 
 // Contextos
 import { AuthProvider } from "./context/AuthContext.jsx";
@@ -67,6 +69,10 @@ const queryClient = new QueryClient({
 // Componente para manejar el layout condicional
 const AppLayout = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
+    setNavigate(navigate);
+  }, [navigate]);
   const isLoginPage = location.pathname.startsWith("/login");
 
   return (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -67,8 +67,6 @@ apiClient.interceptors.response.use(
       localStorage.removeItem("userInfo");
       if (navigator) {
         navigator("/login", { replace: true });
-      } else {
-        window.location.href = "/login";
       }
     } else if (error.response?.status >= 500) {
       console.error("Server error:", error.response.status);


### PR DESCRIPTION
## Summary
- redirect to `/login` using provided navigate function only
- inject navigate instance in `AppLayout`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: npm error code E403: 403 Forbidden - GET https://registry.npmjs.org/mapbox-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cdf74b588327ae2c2bd6f3117981