### PR TITLE
feat: monitor INP with web vitals

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,8 @@
     "three": "^0.179.0",
     "usehooks-ts": "^3.1.0",
     "xlsx": "^0.18.5",
-    "zustand": "^5.0.2"
+    "zustand": "^5.0.2",
+    "web-vitals": "^4.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,14 @@
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { onINP } from "web-vitals";
 
-// Monitor INP metric if web-vitals is available
-(window as any).webVitals?.onINP(console.log);
+// Monitor INP metric using web-vitals
+onINP(({ value }) => {
+  if (value > 200) console.warn("INP necesita mejora:", value);
+  // Enviar valor a un endpoint/analytics si se requiere
+  // fetch("/api/metrics", { method: "POST", body: JSON.stringify({ inp: value }) });
+});
 
 // Global error handler for unhandled promise rejections
 window.addEventListener("unhandledrejection", (event) => {


### PR DESCRIPTION
## Summary
- monitor INP metric using `web-vitals`
- add `web-vitals` dependency

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dbbff1b883278fdb15ea567718c8