### PR TITLE
Remove redirect from debug page

### DIFF
--- a/frontend/public/debug.html
+++ b/frontend/public/debug.html
@@ -76,7 +76,6 @@
         <button class="button" onclick="checkHealth()">Verificar Estado</button>
         <button class="button" onclick="clearUserData()">Limpiar Datos de Usuario</button>
         <button class="button danger" onclick="clearAll()">Limpiar Todo</button>
-        <button class="button" onclick="goToApp()">Ir a la Aplicación</button>
         
         <h2>Información del Sistema</h2>
         <div id="systemInfo"></div>
@@ -156,9 +155,7 @@
             }
         }
 
-        function goToApp() {
-            window.location.href = '/';
-        }
+        // Función de navegación eliminada para evitar recargas inesperadas.
 
         function showSystemInfo() {
             const systemInfo = document.getElementById('systemInfo');


### PR DESCRIPTION
## Summary
- drop "Ir a la Aplicación" button from debug page
- remove direct `window.location` navigation to avoid unexpected reloads

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e3b9816c83278aab09a1a5517f39