### PR TITLE
feat: use icon and dark mode prop for agents function chart

### DIFF
--- a/frontend/src/components/AgentsByFunctionBarChart.jsx
+++ b/frontend/src/components/AgentsByFunctionBarChart.jsx
@@ -12,7 +12,8 @@ import {
 } from "recharts";
 import DashboardCard from "./ui/DashboardCard.jsx";
 import PaginationControls from "./ui/PaginationControls.jsx";
-import { useTheme } from "../context/ThemeContext.jsx";
+import icons from "./ui/icons.js";
+import { useTheme } from "@mui/material/styles";
 import {
   formatMiles,
   formatPct,
@@ -21,8 +22,8 @@ import {
   gridStyle,
 } from "./ui/chart-utils";
 
-const AgentsByFunctionBarChart = ({ data }) => {
-  const { isDarkMode, theme } = useTheme();
+const AgentsByFunctionBarChart = ({ data, isDarkMode }) => {
+  const theme = useTheme();
   const primary = theme.palette.primary.main;
 
   const chartData = useMemo(
@@ -71,7 +72,7 @@ const AgentsByFunctionBarChart = ({ data }) => {
 
   return (
     <DashboardCard
-      icon="work_outline"
+      icon={<icons.contratos />}
       title="Distribución de Agentes por Función - Planta y Contratos"
       isDarkMode={isDarkMode}
       headerRight={

--- a/frontend/src/page/DashboardPage.jsx
+++ b/frontend/src/page/DashboardPage.jsx
@@ -45,6 +45,9 @@ const CustomAreaChart = lazy(() => import("../components/CustomAreaChart"));
 const CustomHorizontalBarChart = lazy(
   () => import("../components/CustomHorizontalBarChart"),
 );
+const AgentsByFunctionBarChart = lazy(
+  () => import("../components/AgentsByFunctionBarChart.jsx"),
+);
 const AgeRangeByAreaChart = lazy(
   () => import("../components/AgeRangeByAreaChart"),
 );
@@ -782,19 +785,14 @@ const DashboardPage = () => {
           {/* gráficos principales */}
           <Grid item xs={12}>
             <Suspense fallback={<CircularProgress />}>
-              <CustomHorizontalBarChart
+              <AgentsByFunctionBarChart
                 data={agentsByFunction.filter(
                   (f) =>
                     f.function &&
                     f.function.trim() !== "" &&
                     f.function.trim() !== "-",
                 )}
-                title="Distribución de Agentes por Función - Planta y Contratos"
                 isDarkMode={isDarkMode}
-                nameKey="function"
-                valueKey="count"
-                pageSize={10}
-                height={520}
               />
             </Suspense>
           </Grid>


### PR DESCRIPTION
## Summary
- refactor AgentsByFunctionBarChart to take `isDarkMode` prop and render contratos icon
- load AgentsByFunctionBarChart in dashboard and propagate dark mode

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e4a739b88327b10c06061d3ebef1