### PR TITLE
Wrap StatsWidget content in DashboardCard

### DIFF
--- a/frontend/src/components/StatsWidget.jsx
+++ b/frontend/src/components/StatsWidget.jsx
@@ -1,20 +1,28 @@
 import React from "react";
 import { Box, Grid, Typography } from "@mui/material";
 import KPIStat from "./KPIStat.jsx";
+import DashboardCard from "./ui/DashboardCard.jsx";
+import { icons } from "./ui";
 
 const StatsWidget = ({ data, isDarkMode }) => {
   if (!data) {
     return (
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        height="100%"
+      <DashboardCard
+        title="Resumen general"
+        icon={<icons.resumen />}
+        isDarkMode={isDarkMode}
       >
-        <Typography variant="body2" color="text.secondary">
-          No hay datos de resumen disponibles
-        </Typography>
-      </Box>
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          height="100%"
+        >
+          <Typography variant="body2" color="text.secondary">
+            No hay datos de resumen disponibles
+          </Typography>
+        </Box>
+      </DashboardCard>
     );
   }
 
@@ -58,23 +66,29 @@ const StatsWidget = ({ data, isDarkMode }) => {
   ];
 
   return (
-    <Box sx={{ height: "100%", p: 1 }}>
-      <Grid container spacing={2} sx={{ height: "100%" }}>
-        {stats.map((stat, index) => (
-          <Grid item xs={6} md={3} key={index} sx={{ height: "50%" }}>
-            <KPIStat {...stat} isDarkMode={isDarkMode} />
-          </Grid>
-        ))}
-      </Grid>
-      {data.ultimaActualizacion && (
-        <Box sx={{ mt: 2, textAlign: "center" }}>
-          <Typography variant="caption" color="text.secondary">
-            Última actualización:{" "}
-            {new Date(data.ultimaActualizacion).toLocaleString("es-AR")}
-          </Typography>
-        </Box>
-      )}
-    </Box>
+    <DashboardCard
+      title="Resumen general"
+      icon={<icons.resumen />}
+      isDarkMode={isDarkMode}
+    >
+      <Box sx={{ height: "100%" }}>
+        <Grid container spacing={2} sx={{ height: "100%" }}>
+          {stats.map((stat, index) => (
+            <Grid item xs={6} md={3} key={index} sx={{ height: "50%" }}>
+              <KPIStat {...stat} isDarkMode={isDarkMode} />
+            </Grid>
+          ))}
+        </Grid>
+        {data.ultimaActualizacion && (
+          <Box sx={{ mt: 2, textAlign: "center" }}>
+            <Typography variant="caption" color="text.secondary">
+              Última actualización:{" "}
+              {new Date(data.ultimaActualizacion).toLocaleString("es-AR")}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </DashboardCard>
   );
 };
 


### PR DESCRIPTION
## Summary
- use DashboardCard to wrap StatsWidget contents and add resumen icon

## Testing
- `npm run lint` *(fails: npm: command not found)*
- `npm test` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e6622d24832792dae2da1d1f0fdd