### PR TITLE
Use react-router path for error reporting

### DIFF
--- a/frontend/src/components/ErrorFallback.jsx
+++ b/frontend/src/components/ErrorFallback.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import {
   Box,
   Card,
@@ -22,6 +22,7 @@ import {
 
 const ErrorFallback = ({ error, resetErrorBoundary }) => {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const handleReportError = () => {
     // Aquí se podría enviar el error a un servicio de logging
     console.error("Error reportado:", error);
@@ -32,7 +33,7 @@ const ErrorFallback = ({ error, resetErrorBoundary }) => {
       stack: error.stack,
       timestamp: new Date().toISOString(),
       userAgent: navigator.userAgent,
-      url: window.location.href,
+      url: pathname,
     };
 
     // En una implementación real, esto se enviaría a un servicio como Sentry


### PR DESCRIPTION
## Summary
- Capture current route in `ErrorFallback` using `useLocation` instead of `window.location`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/web-vitals)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e788f8e88327bb194e43dfc4844a