### PR TITLE
feat: refine theme tokens

### DIFF
--- a/frontend/src/components/ui/DashboardCard.jsx
+++ b/frontend/src/components/ui/DashboardCard.jsx
@@ -21,6 +21,10 @@ const DashboardCard = ({
         border: isDarkMode
           ? "1px solid rgba(255,255,255,0.1)"
           : "1px solid rgba(0,0,0,0.08)",
+        transition: "background-color 0.2s ease",
+        "&:hover": {
+          backgroundColor: theme.palette.primaryHover,
+        },
       }}
     >
       {(title || subtitle || headerRight) && (

--- a/frontend/src/components/ui/theme.js
+++ b/frontend/src/components/ui/theme.js
@@ -1,6 +1,7 @@
 const palette = {
   primary: "#3b82f6",
   primaryLight: "#60a5fa",
+  primaryHover: "rgba(59,130,246,0.15)",
   backgroundLight: "#ffffff",
   backgroundDark: "#1e293b",
   textLight: "#0f172a",
@@ -12,14 +13,14 @@ const palette = {
 const radii = {
   sm: 4,
   md: 8,
-  lg: 12,
+  lg: 16,
 };
 
 const shadows = {
   sm: "0 1px 2px rgba(0,0,0,0.05)",
   md: "0 4px 6px rgba(0,0,0,0.1)",
   lg: "0 10px 15px rgba(0,0,0,0.15)",
-  dashboard: "0 4px 8px rgba(0,0,0,0.1)",
+  dashboard: "0 6px 18px rgba(2,6,23,0.12)",
 };
 
 const typography = {


### PR DESCRIPTION
## Summary
- add `primaryHover` color and expand theme radii & shadows
- apply new hover color to DashboardCard and keep tokens for radius and shadow

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1eb7e4f3083278f50300333cf5944