### PR TITLE
feat: show percentages in chart labels

### DIFF
--- a/frontend/src/components/AgeRangeByAreaChart.jsx
+++ b/frontend/src/components/AgeRangeByAreaChart.jsx
@@ -102,9 +102,8 @@ const AgeRangeByAreaChart = ({ rows, isDarkMode }) => {
 
   const dynamicRight = useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map(
-      (d) =>
-        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (total || 1))})`,
+    const labels = pageData.map((d) =>
+      formatPct((d.cantidad || 0) / (total || 1)),
     );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;

--- a/frontend/src/components/AgentsByDepartamentoBarChart.jsx
+++ b/frontend/src/components/AgentsByDepartamentoBarChart.jsx
@@ -42,9 +42,8 @@ const AgentsByDepartamentoBarChart = ({ data, isDarkMode }) => {
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map(
-      (d) =>
-        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    const labels = pageData.map((d) =>
+      formatPct((d.cantidad || 0) / (grandTotal || 1)),
     );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
@@ -54,7 +53,7 @@ const AgentsByDepartamentoBarChart = ({ data, isDarkMode }) => {
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
-    const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
+    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
     const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
       <text

--- a/frontend/src/components/AgentsByDependencyBarChart.jsx
+++ b/frontend/src/components/AgentsByDependencyBarChart.jsx
@@ -41,9 +41,8 @@ const AgentsByDependencyBarChart = ({ data, isDarkMode }) => {
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map(
-      (d) =>
-        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    const labels = pageData.map((d) =>
+      formatPct((d.cantidad || 0) / (grandTotal || 1)),
     );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
@@ -53,7 +52,7 @@ const AgentsByDependencyBarChart = ({ data, isDarkMode }) => {
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
-    const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
+    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
     const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
       <text

--- a/frontend/src/components/AgentsByDireccionBarChart.jsx
+++ b/frontend/src/components/AgentsByDireccionBarChart.jsx
@@ -41,9 +41,8 @@ const AgentsByDireccionBarChart = ({ data, isDarkMode }) => {
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map(
-      (d) =>
-        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    const labels = pageData.map((d) =>
+      formatPct((d.cantidad || 0) / (grandTotal || 1)),
     );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
@@ -53,7 +52,7 @@ const AgentsByDireccionBarChart = ({ data, isDarkMode }) => {
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
-    const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
+    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
     const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
       <text

--- a/frontend/src/components/AgentsByDireccionGeneralBarChart.jsx
+++ b/frontend/src/components/AgentsByDireccionGeneralBarChart.jsx
@@ -42,9 +42,8 @@ const AgentsByDireccionGeneralBarChart = ({ data, isDarkMode }) => {
   const MAX_RIGHT = 260;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map(
-      (d) =>
-        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    const labels = pageData.map((d) =>
+      formatPct((d.cantidad || 0) / (grandTotal || 1)),
     );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
@@ -54,7 +53,7 @@ const AgentsByDireccionGeneralBarChart = ({ data, isDarkMode }) => {
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
-    const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
+    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
     const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
       <text

--- a/frontend/src/components/AgentsByDivisionBarChart.jsx
+++ b/frontend/src/components/AgentsByDivisionBarChart.jsx
@@ -41,9 +41,8 @@ const AgentsByDivisionBarChart = ({ data, isDarkMode }) => {
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map(
-      (d) =>
-        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    const labels = pageData.map((d) =>
+      formatPct((d.cantidad || 0) / (grandTotal || 1)),
     );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
@@ -53,7 +52,7 @@ const AgentsByDivisionBarChart = ({ data, isDarkMode }) => {
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
-    const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
+    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
     const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
       <text

--- a/frontend/src/components/AgentsByFunctionBarChart.jsx
+++ b/frontend/src/components/AgentsByFunctionBarChart.jsx
@@ -52,7 +52,7 @@ const AgentsByFunctionBarChart = ({ data, isDarkMode }) => {
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const v = Number(pageData?.[index]?.cantidad) || 0;
-    const label = `${formatMiles(v)} (${formatPct(total ? v / total : 0)})`;
+    const label = formatPct(total ? v / total : 0);
     const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
       <text

--- a/frontend/src/components/AgentsBySecretariaBarChart.jsx
+++ b/frontend/src/components/AgentsBySecretariaBarChart.jsx
@@ -44,10 +44,9 @@ const AgentsBySecretariaBarChart = ({ data, isDarkMode }) => {
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map((d) => {
-      const cnt = Number(d.cantidad || 0);
-      return `${formatMiles(cnt)} (${formatPct((cnt || 0) / (grandTotal || 1))})`;
-    });
+    const labels = pageData.map((d) =>
+      formatPct((Number(d.cantidad) || 0) / (grandTotal || 1)),
+    );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20; // 7px por carácter + padding
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
@@ -58,7 +57,7 @@ const AgentsBySecretariaBarChart = ({ data, isDarkMode }) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
     const cnt = Number(row.cantidad ?? 0);
-    const label = `${formatMiles(cnt)} (${formatPct((cnt || 0) / (grandTotal || 1))})`;
+    const label = formatPct((cnt || 0) / (grandTotal || 1));
     const xText = x + width + 8;
     const yText = y + (height || 0) / 2;
     const color = isDarkMode ? "#ffffff" : "#0f172a";

--- a/frontend/src/components/AgentsBySubsecretariaBarChart.jsx
+++ b/frontend/src/components/AgentsBySubsecretariaBarChart.jsx
@@ -42,9 +42,8 @@ const AgentsBySubsecretariaBarChart = ({ data, isDarkMode }) => {
   const MAX_RIGHT = 240;
   const dynamicRight = React.useMemo(() => {
     if (!pageData?.length) return MIN_RIGHT;
-    const labels = pageData.map(
-      (d) =>
-        `${formatMiles(d.cantidad)} (${formatPct((d.cantidad || 0) / (grandTotal || 1))})`,
+    const labels = pageData.map((d) =>
+      formatPct((d.cantidad || 0) / (grandTotal || 1)),
     );
     const maxChars = Math.max(...labels.map((t) => t.length));
     const approxWidth = maxChars * 7 + 20;
@@ -54,7 +53,7 @@ const AgentsBySubsecretariaBarChart = ({ data, isDarkMode }) => {
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
     const row = pageData?.[index] || {};
-    const label = `${formatMiles(row.cantidad || 0)} (${formatPct((row.cantidad || 0) / (grandTotal || 1))})`;
+    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
     const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
       <text

--- a/frontend/src/components/CustomHorizontalBarChart.jsx
+++ b/frontend/src/components/CustomHorizontalBarChart.jsx
@@ -105,15 +105,9 @@ const CustomHorizontalBarChart = ({
   const ValueLabel = (props) => {
     const { x = 0, y = 0, width = 0, value = 0, viewBox } = props;
     const chartW = viewBox?.width ?? 0;
-
-    let text = `${formatMiles(value)} (${formatPct(total ? value / total : 0)})`;
+    const text = formatPct(total ? value / total : 0);
     const barEndX = x + width;
-
-    if (barEndX + RIGHT_PAD + text.length * 7 > chartW - 4) {
-      text = `${formatShort(value)} (${formatPct(total ? value / total : 0)})`;
-    }
-
-    const textX = barEndX + RIGHT_PAD;
+    const textX = Math.min(barEndX + RIGHT_PAD, chartW - text.length * 7 - 4);
     const fill = theme.palette.text.primary;
 
     return (

--- a/frontend/src/components/EmploymentTypeBarChart.jsx
+++ b/frontend/src/components/EmploymentTypeBarChart.jsx
@@ -31,7 +31,7 @@ const EmploymentTypeBarChart = ({ data, isDarkMode }) => {
 
   const EndOutsideLabel = (props) => {
     const { x = 0, y = 0, width = 0, height = 0, value = 0 } = props;
-    const label = `${formatMiles(Number(value))} (${formatPct(total ? Number(value) / total : 0)})`;
+    const label = formatPct(total ? Number(value) / total : 0);
     const color = isDarkMode ? "#ffffff" : "#0f172a";
     return (
       <text

--- a/frontend/src/components/ui/chart-utils.tsx
+++ b/frontend/src/components/ui/chart-utils.tsx
@@ -113,7 +113,7 @@ type RechartsLabelProps = {
 export const ValueLabel: React.FC<RechartsLabelProps> = (p) => {
   const { x = 0, y = 0, width = 0, value = 0, viewBox, total = 1, dark } = p;
   const chartW = viewBox?.width ?? 0;
-  const text = `${formatMiles(Number(value))} (${formatPct(Number(value) / Number(total || 1))})`;
+  const text = formatPct(Number(value) / Number(total || 1));
   const approx = text.length * 7;
   const xText = Math.min(x + width + RIGHT_PAD, chartW - approx - 4);
   const isDarkTheme = typeof dark === "boolean" ? dark : isDark();


### PR DESCRIPTION
## Summary
- show only percentages in chart ValueLabel
- update horizontal bar charts to remove raw counts from bar labels

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ec7c3f8c832788ec16f211593513