### PR TITLE
refactor: standardize agent bar charts

### DIFF
--- a/frontend/src/components/AgentsByDepartamentoBarChart.jsx
+++ b/frontend/src/components/AgentsByDepartamentoBarChart.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
-import ApartmentIcon from "@mui/icons-material/Apartment";
+import { Typography, Box, Chip } from "@mui/material";
 import {
   BarChart,
   Bar,
@@ -11,12 +10,23 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
-import { formatMiles, formatPct, UnifiedTooltip } from "./ui/chart-utils";
+import DashboardCard from "./ui/DashboardCard.jsx";
 import PaginationControls from "./ui/PaginationControls.jsx";
-
-const COLOR = "#f43f5e";
+import {
+  formatMiles,
+  formatPct,
+  UnifiedTooltip,
+  rechartsCommon,
+  ValueLabel,
+} from "./ui/chart-utils";
+import icons from "./ui/icons.js";
+import { useTheme } from "../context/ThemeContext.jsx";
 
 const AgentsByDepartamentoBarChart = ({ data, isDarkMode }) => {
+  const { theme } = useTheme();
+  const primary = theme.palette.primary.main;
+  const { axisProps, gridProps, tooltipProps } = rechartsCommon(isDarkMode);
+
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
       departamento:
@@ -50,173 +60,111 @@ const AgentsByDepartamentoBarChart = ({ data, isDarkMode }) => {
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
   }, [pageData, grandTotal]);
 
-  const EndOutsideLabel = (props) => {
-    const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
-    const row = pageData?.[index] || {};
-    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
-    const color = isDarkMode ? "#ffffff" : "#0f172a";
-    return (
-      <text
-        x={x + width + 8}
-        y={y + (height || 0) / 2}
-        fontSize={12}
-        textAnchor="start"
-        dominantBaseline="central"
-        fill={color}
-        fontWeight="600"
-        pointerEvents="none"
-      >
-        {label}
-      </text>
-    );
-  };
-
   return (
-    <Card
-      sx={{
-        height: "100%",
-        background: isDarkMode
-          ? "rgba(45, 55, 72, 0.8)"
-          : "rgba(255, 255, 255, 0.9)",
-        backdropFilter: "blur(20px)",
-        border: isDarkMode
-          ? "1px solid rgba(255, 255, 255, 0.1)"
-          : "1px solid rgba(0, 0, 0, 0.08)",
-        borderLeft: `6px solid ${COLOR}`,
-        borderRadius: 3,
-        transition: "all 0.3s ease",
-        "&:hover": {
-          transform: "translateY(-4px)",
-          boxShadow: isDarkMode
-            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
-            : "0 12px 40px rgba(0, 0, 0, 0.15)",
-        },
-      }}
+    <DashboardCard
+      title="Agentes por Departamento - Planta y Contratos"
+      icon={<icons.distribucion />}
+      isDarkMode={isDarkMode}
+      headerRight={
+        <Chip
+          label="Departamento"
+          size="small"
+          variant="outlined"
+          sx={{ borderColor: primary, color: primary }}
+        />
+      }
     >
-      <CardContent sx={{ p: 3 }}>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 1.25,
-          }}
-        >
-          <ApartmentIcon sx={{ color: COLOR }} />
-          <Typography
-            variant="h6"
-            align="center"
-            sx={{
-              fontWeight: 600,
-              color: isDarkMode
-                ? "rgba(255, 255, 255, 0.9)"
-                : "rgba(0, 0, 0, 0.8)",
-            }}
+      <Typography
+        variant="body2"
+        align="center"
+        sx={{
+          mb: 2,
+          color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+        }}
+      >
+        {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      </Typography>
+      <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
           >
-            Agentes por Departamento - Planta y Contratos
-          </Typography>
-          <Chip
-            label="Departamento"
-            size="small"
-            variant="outlined"
-            sx={{ borderColor: COLOR, color: COLOR }}
-          />
-        </Box>
-        <Typography
-          variant="body2"
-          align="center"
-          sx={{
-            mb: 2,
-            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
-          }}
-        >
-          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
-        </Typography>
-        <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={pageData}
-              layout="vertical"
-              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
-              barCategoryGap={10}
-            >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={
-                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
-                }
-              />
-              <XAxis
-                type="number"
-                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
-                allowDecimals={false}
-                tickFormatter={formatMiles}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                }}
-              />
-              <YAxis
-                type="category"
-                dataKey="departamento"
-                width={240}
-                tickLine={false}
-                interval={0}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                  fontSize: 12,
-                }}
-              />
-              <Tooltip
-                wrapperStyle={{ outline: "none" }}
-                content={({ active, payload }) => (
-                  <UnifiedTooltip
-                    active={active}
-                    payload={payload}
+            <CartesianGrid
+              {...gridProps}
+              horizontal={false}
+              strokeDasharray="0 0"
+            />
+            <XAxis
+              {...axisProps}
+              type="number"
+              domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+              allowDecimals={false}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisProps}
+              type="category"
+              dataKey="departamento"
+              width={240}
+              tickLine={false}
+              interval={0}
+            />
+            <Tooltip
+              {...tooltipProps}
+              content={({ active, payload }) => (
+                <UnifiedTooltip
+                  active={active}
+                  payload={payload}
+                  dark={isDarkMode}
+                  label={`Departamento: ${
+                    payload?.[0]?.payload?.departamento || "Sin especificar"
+                  }`}
+                >
+                  {payload?.length && (
+                    <>
+                      <div>
+                        Cantidad de agentes: {" "}
+                        {formatMiles(payload[0].payload.cantidad)}
+                      </div>
+                      <div>
+                        Porcentaje: {" "}
+                        {formatPct(
+                          (payload[0].payload.cantidad || 0) /
+                            (grandTotal || 1),
+                        )}
+                      </div>
+                    </>
+                  )}
+                </UnifiedTooltip>
+              )}
+            />
+            <Bar dataKey="cantidad" maxBarSize={22} fill={primary}>
+              <LabelList
+                dataKey="cantidad"
+                content={(p) => (
+                  <ValueLabel
+                    {...p}
+                    total={grandTotal}
                     dark={isDarkMode}
-                    label={`Departamento: ${payload?.[0]?.payload?.departamento || "Sin especificar"}`}
-                  >
-                    {payload?.length && (
-                      <>
-                        <div>
-                          Cantidad de agentes:{" "}
-                          {formatMiles(payload[0].payload.cantidad)}
-                        </div>
-                        <div>
-                          Porcentaje:{" "}
-                          {formatPct(
-                            (payload[0].payload.cantidad || 0) /
-                              (grandTotal || 1),
-                          )}
-                        </div>
-                      </>
-                    )}
-                  </UnifiedTooltip>
+                  />
                 )}
               />
-              <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList
-                  dataKey="cantidad"
-                  content={(p) => <EndOutsideLabel {...p} />}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {chartData.length > PAGE && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages}
-            onPrev={() => setPage((p) => Math.max(0, p - 1))}
-            onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-          />
-        )}
-      </CardContent>
-    </Card>
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {chartData.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      )}
+    </DashboardCard>
   );
 };
 

--- a/frontend/src/components/AgentsByDependencyBarChart.jsx
+++ b/frontend/src/components/AgentsByDependencyBarChart.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
-import HubIcon from "@mui/icons-material/Hub";
+import { Typography, Box, Chip } from "@mui/material";
 import {
   BarChart,
   Bar,
@@ -11,12 +10,23 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
-import { formatMiles, formatPct, UnifiedTooltip } from "./ui/chart-utils";
+import DashboardCard from "./ui/DashboardCard.jsx";
 import PaginationControls from "./ui/PaginationControls.jsx";
-
-const COLOR = "#6366f1";
+import {
+  formatMiles,
+  formatPct,
+  UnifiedTooltip,
+  rechartsCommon,
+  ValueLabel,
+} from "./ui/chart-utils";
+import icons from "./ui/icons.js";
+import { useTheme } from "../context/ThemeContext.jsx";
 
 const AgentsByDependencyBarChart = ({ data, isDarkMode }) => {
+  const { theme } = useTheme();
+  const primary = theme.palette.primary.main;
+  const { axisProps, gridProps, tooltipProps } = rechartsCommon(isDarkMode);
+
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
       dependency: (d.dependency ?? "").toString().trim() || "Sin especificar",
@@ -49,173 +59,111 @@ const AgentsByDependencyBarChart = ({ data, isDarkMode }) => {
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
   }, [pageData, grandTotal]);
 
-  const EndOutsideLabel = (props) => {
-    const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
-    const row = pageData?.[index] || {};
-    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
-    const color = isDarkMode ? "#ffffff" : "#0f172a";
-    return (
-      <text
-        x={x + width + 8}
-        y={y + (height || 0) / 2}
-        fontSize={12}
-        textAnchor="start"
-        dominantBaseline="central"
-        fill={color}
-        fontWeight="600"
-        pointerEvents="none"
-      >
-        {label}
-      </text>
-    );
-  };
-
   return (
-    <Card
-      sx={{
-        height: "100%",
-        background: isDarkMode
-          ? "rgba(45, 55, 72, 0.8)"
-          : "rgba(255, 255, 255, 0.9)",
-        backdropFilter: "blur(20px)",
-        border: isDarkMode
-          ? "1px solid rgba(255, 255, 255, 0.1)"
-          : "1px solid rgba(0, 0, 0, 0.08)",
-        borderLeft: `6px solid ${COLOR}`,
-        borderRadius: 3,
-        transition: "all 0.3s ease",
-        "&:hover": {
-          transform: "translateY(-4px)",
-          boxShadow: isDarkMode
-            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
-            : "0 12px 40px rgba(0, 0, 0, 0.15)",
-        },
-      }}
+    <DashboardCard
+      title="Agentes por Dependencia - Planta y Contratos"
+      icon={<icons.distribucion />}
+      isDarkMode={isDarkMode}
+      headerRight={
+        <Chip
+          label="Dependencia"
+          size="small"
+          variant="outlined"
+          sx={{ borderColor: primary, color: primary }}
+        />
+      }
     >
-      <CardContent sx={{ p: 3 }}>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 1.25,
-          }}
-        >
-          <HubIcon sx={{ color: COLOR }} />
-          <Typography
-            variant="h6"
-            align="center"
-            sx={{
-              fontWeight: 600,
-              color: isDarkMode
-                ? "rgba(255, 255, 255, 0.9)"
-                : "rgba(0, 0, 0, 0.8)",
-            }}
+      <Typography
+        variant="body2"
+        align="center"
+        sx={{
+          mb: 2,
+          color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+        }}
+      >
+        {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      </Typography>
+      <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
           >
-            Agentes por Dependencia - Planta y Contratos
-          </Typography>
-          <Chip
-            label="Dependencia"
-            size="small"
-            variant="outlined"
-            sx={{ borderColor: COLOR, color: COLOR }}
-          />
-        </Box>
-        <Typography
-          variant="body2"
-          align="center"
-          sx={{
-            mb: 2,
-            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
-          }}
-        >
-          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
-        </Typography>
-        <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={pageData}
-              layout="vertical"
-              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
-              barCategoryGap={10}
-            >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={
-                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
-                }
-              />
-              <XAxis
-                type="number"
-                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
-                allowDecimals={false}
-                tickFormatter={formatMiles}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                }}
-              />
-              <YAxis
-                type="category"
-                dataKey="dependency"
-                width={240}
-                tickLine={false}
-                interval={0}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                  fontSize: 12,
-                }}
-              />
-              <Tooltip
-                wrapperStyle={{ outline: "none" }}
-                content={({ active, payload }) => (
-                  <UnifiedTooltip
-                    active={active}
-                    payload={payload}
+            <CartesianGrid
+              {...gridProps}
+              horizontal={false}
+              strokeDasharray="0 0"
+            />
+            <XAxis
+              {...axisProps}
+              type="number"
+              domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+              allowDecimals={false}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisProps}
+              type="category"
+              dataKey="dependency"
+              width={240}
+              tickLine={false}
+              interval={0}
+            />
+            <Tooltip
+              {...tooltipProps}
+              content={({ active, payload }) => (
+                <UnifiedTooltip
+                  active={active}
+                  payload={payload}
+                  dark={isDarkMode}
+                  label={`Dependencia: ${
+                    payload?.[0]?.payload?.dependency || "Sin especificar"
+                  }`}
+                >
+                  {payload?.length && (
+                    <>
+                      <div>
+                        Cantidad de agentes: {" "}
+                        {formatMiles(payload[0].payload.cantidad)}
+                      </div>
+                      <div>
+                        Porcentaje: {" "}
+                        {formatPct(
+                          (payload[0].payload.cantidad || 0) /
+                            (grandTotal || 1),
+                        )}
+                      </div>
+                    </>
+                  )}
+                </UnifiedTooltip>
+              )}
+            />
+            <Bar dataKey="cantidad" maxBarSize={22} fill={primary}>
+              <LabelList
+                dataKey="cantidad"
+                content={(p) => (
+                  <ValueLabel
+                    {...p}
+                    total={grandTotal}
                     dark={isDarkMode}
-                    label={`Dependencia: ${payload?.[0]?.payload?.dependency || "Sin especificar"}`}
-                  >
-                    {payload?.length && (
-                      <>
-                        <div>
-                          Cantidad de agentes:{" "}
-                          {formatMiles(payload[0].payload.cantidad)}
-                        </div>
-                        <div>
-                          Porcentaje:{" "}
-                          {formatPct(
-                            (payload[0].payload.cantidad || 0) /
-                              (grandTotal || 1),
-                          )}
-                        </div>
-                      </>
-                    )}
-                  </UnifiedTooltip>
+                  />
                 )}
               />
-              <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList
-                  dataKey="cantidad"
-                  content={(p) => <EndOutsideLabel {...p} />}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {chartData.length > PAGE && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages}
-            onPrev={() => setPage((p) => Math.max(0, p - 1))}
-            onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-          />
-        )}
-      </CardContent>
-    </Card>
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {chartData.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      )}
+    </DashboardCard>
   );
 };
 

--- a/frontend/src/components/AgentsByDireccionBarChart.jsx
+++ b/frontend/src/components/AgentsByDireccionBarChart.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
-import AltRouteIcon from "@mui/icons-material/AltRoute";
+import { Typography, Box, Chip } from "@mui/material";
 import {
   BarChart,
   Bar,
@@ -11,12 +10,23 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
-import { formatMiles, formatPct, UnifiedTooltip } from "./ui/chart-utils";
+import DashboardCard from "./ui/DashboardCard.jsx";
 import PaginationControls from "./ui/PaginationControls.jsx";
-
-const COLOR = "#06b6d4";
+import {
+  formatMiles,
+  formatPct,
+  UnifiedTooltip,
+  rechartsCommon,
+  ValueLabel,
+} from "./ui/chart-utils";
+import icons from "./ui/icons.js";
+import { useTheme } from "../context/ThemeContext.jsx";
 
 const AgentsByDireccionBarChart = ({ data, isDarkMode }) => {
+  const { theme } = useTheme();
+  const primary = theme.palette.primary.main;
+  const { axisProps, gridProps, tooltipProps } = rechartsCommon(isDarkMode);
+
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
       direccion: (d.direccion ?? "").toString().trim() || "Sin especificar",
@@ -49,173 +59,111 @@ const AgentsByDireccionBarChart = ({ data, isDarkMode }) => {
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
   }, [pageData, grandTotal]);
 
-  const EndOutsideLabel = (props) => {
-    const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
-    const row = pageData?.[index] || {};
-    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
-    const color = isDarkMode ? "#ffffff" : "#0f172a";
-    return (
-      <text
-        x={x + width + 8}
-        y={y + (height || 0) / 2}
-        fontSize={12}
-        textAnchor="start"
-        dominantBaseline="central"
-        fill={color}
-        fontWeight="600"
-        pointerEvents="none"
-      >
-        {label}
-      </text>
-    );
-  };
-
   return (
-    <Card
-      sx={{
-        height: "100%",
-        background: isDarkMode
-          ? "rgba(45, 55, 72, 0.8)"
-          : "rgba(255, 255, 255, 0.9)",
-        backdropFilter: "blur(20px)",
-        border: isDarkMode
-          ? "1px solid rgba(255, 255, 255, 0.1)"
-          : "1px solid rgba(0, 0, 0, 0.08)",
-        borderLeft: `6px solid ${COLOR}`,
-        borderRadius: 3,
-        transition: "all 0.3s ease",
-        "&:hover": {
-          transform: "translateY(-4px)",
-          boxShadow: isDarkMode
-            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
-            : "0 12px 40px rgba(0, 0, 0, 0.15)",
-        },
-      }}
+    <DashboardCard
+      title="Agentes por Dirección - Planta y Contratos"
+      icon={<icons.distribucion />}
+      isDarkMode={isDarkMode}
+      headerRight={
+        <Chip
+          label="Dirección"
+          size="small"
+          variant="outlined"
+          sx={{ borderColor: primary, color: primary }}
+        />
+      }
     >
-      <CardContent sx={{ p: 3 }}>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 1.25,
-          }}
-        >
-          <AltRouteIcon sx={{ color: COLOR }} />
-          <Typography
-            variant="h6"
-            align="center"
-            sx={{
-              fontWeight: 600,
-              color: isDarkMode
-                ? "rgba(255, 255, 255, 0.9)"
-                : "rgba(0, 0, 0, 0.8)",
-            }}
+      <Typography
+        variant="body2"
+        align="center"
+        sx={{
+          mb: 2,
+          color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+        }}
+      >
+        {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      </Typography>
+      <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
           >
-            Agentes por direccion - Planta y Contratos
-          </Typography>
-          <Chip
-            label="Dirección"
-            size="small"
-            variant="outlined"
-            sx={{ borderColor: COLOR, color: COLOR }}
-          />
-        </Box>
-        <Typography
-          variant="body2"
-          align="center"
-          sx={{
-            mb: 2,
-            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
-          }}
-        >
-          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
-        </Typography>
-        <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={pageData}
-              layout="vertical"
-              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
-              barCategoryGap={10}
-            >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={
-                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
-                }
-              />
-              <XAxis
-                type="number"
-                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
-                allowDecimals={false}
-                tickFormatter={formatMiles}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                }}
-              />
-              <YAxis
-                type="category"
-                dataKey="direccion"
-                width={240}
-                tickLine={false}
-                interval={0}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                  fontSize: 12,
-                }}
-              />
-              <Tooltip
-                wrapperStyle={{ outline: "none" }}
-                content={({ active, payload }) => (
-                  <UnifiedTooltip
-                    active={active}
-                    payload={payload}
+            <CartesianGrid
+              {...gridProps}
+              horizontal={false}
+              strokeDasharray="0 0"
+            />
+            <XAxis
+              {...axisProps}
+              type="number"
+              domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+              allowDecimals={false}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisProps}
+              type="category"
+              dataKey="direccion"
+              width={240}
+              tickLine={false}
+              interval={0}
+            />
+            <Tooltip
+              {...tooltipProps}
+              content={({ active, payload }) => (
+                <UnifiedTooltip
+                  active={active}
+                  payload={payload}
+                  dark={isDarkMode}
+                  label={`Dirección: ${
+                    payload?.[0]?.payload?.direccion || "Sin especificar"
+                  }`}
+                >
+                  {payload?.length && (
+                    <>
+                      <div>
+                        Cantidad de agentes: {" "}
+                        {formatMiles(payload[0].payload.cantidad)}
+                      </div>
+                      <div>
+                        Porcentaje: {" "}
+                        {formatPct(
+                          (payload[0].payload.cantidad || 0) /
+                            (grandTotal || 1),
+                        )}
+                      </div>
+                    </>
+                  )}
+                </UnifiedTooltip>
+              )}
+            />
+            <Bar dataKey="cantidad" maxBarSize={22} fill={primary}>
+              <LabelList
+                dataKey="cantidad"
+                content={(p) => (
+                  <ValueLabel
+                    {...p}
+                    total={grandTotal}
                     dark={isDarkMode}
-                    label={`Dirección: ${payload?.[0]?.payload?.direccion || "Sin especificar"}`}
-                  >
-                    {payload?.length && (
-                      <>
-                        <div>
-                          Cantidad de agentes:{" "}
-                          {formatMiles(payload[0].payload.cantidad)}
-                        </div>
-                        <div>
-                          Porcentaje:{" "}
-                          {formatPct(
-                            (payload[0].payload.cantidad || 0) /
-                              (grandTotal || 1),
-                          )}
-                        </div>
-                      </>
-                    )}
-                  </UnifiedTooltip>
+                  />
                 )}
               />
-              <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList
-                  dataKey="cantidad"
-                  content={(p) => <EndOutsideLabel {...p} />}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {chartData.length > PAGE && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages}
-            onPrev={() => setPage((p) => Math.max(0, p - 1))}
-            onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-          />
-        )}
-      </CardContent>
-    </Card>
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {chartData.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      )}
+    </DashboardCard>
   );
 };
 

--- a/frontend/src/components/AgentsByDireccionGeneralBarChart.jsx
+++ b/frontend/src/components/AgentsByDireccionGeneralBarChart.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
-import CorporateFareIcon from "@mui/icons-material/CorporateFare";
+import { Typography, Box, Chip } from "@mui/material";
 import {
   BarChart,
   Bar,
@@ -11,12 +10,23 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
-import { formatMiles, formatPct, UnifiedTooltip } from "./ui/chart-utils";
+import DashboardCard from "./ui/DashboardCard.jsx";
 import PaginationControls from "./ui/PaginationControls.jsx";
-
-const COLOR = "#a855f7";
+import {
+  formatMiles,
+  formatPct,
+  UnifiedTooltip,
+  rechartsCommon,
+  ValueLabel,
+} from "./ui/chart-utils";
+import icons from "./ui/icons.js";
+import { useTheme } from "../context/ThemeContext.jsx";
 
 const AgentsByDireccionGeneralBarChart = ({ data, isDarkMode }) => {
+  const { theme } = useTheme();
+  const primary = theme.palette.primary.main;
+  const { axisProps, gridProps, tooltipProps } = rechartsCommon(isDarkMode);
+
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
       direccionGeneral:
@@ -50,173 +60,112 @@ const AgentsByDireccionGeneralBarChart = ({ data, isDarkMode }) => {
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
   }, [pageData, grandTotal]);
 
-  const EndOutsideLabel = (props) => {
-    const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
-    const row = pageData?.[index] || {};
-    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
-    const color = isDarkMode ? "#ffffff" : "#0f172a";
-    return (
-      <text
-        x={x + width + 8}
-        y={y + (height || 0) / 2}
-        fontSize={12}
-        textAnchor="start"
-        dominantBaseline="central"
-        fill={color}
-        fontWeight="600"
-        pointerEvents="none"
-      >
-        {label}
-      </text>
-    );
-  };
-
   return (
-    <Card
-      sx={{
-        height: "100%",
-        background: isDarkMode
-          ? "rgba(45, 55, 72, 0.8)"
-          : "rgba(255, 255, 255, 0.9)",
-        backdropFilter: "blur(20px)",
-        border: isDarkMode
-          ? "1px solid rgba(255, 255, 255, 0.1)"
-          : "1px solid rgba(0, 0, 0, 0.08)",
-        borderLeft: `6px solid ${COLOR}`,
-        borderRadius: 3,
-        transition: "all 0.3s ease",
-        "&:hover": {
-          transform: "translateY(-4px)",
-          boxShadow: isDarkMode
-            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
-            : "0 12px 40px rgba(0, 0, 0, 0.15)",
-        },
-      }}
+    <DashboardCard
+      title="Agentes por Dirección General - Planta y Contratos"
+      icon={<icons.distribucion />}
+      isDarkMode={isDarkMode}
+      headerRight={
+        <Chip
+          label="Dirección General"
+          size="small"
+          variant="outlined"
+          sx={{ borderColor: primary, color: primary }}
+        />
+      }
     >
-      <CardContent sx={{ p: 3 }}>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 1.25,
-          }}
-        >
-          <CorporateFareIcon sx={{ color: COLOR }} />
-          <Typography
-            variant="h6"
-            align="center"
-            sx={{
-              fontWeight: 600,
-              color: isDarkMode
-                ? "rgba(255, 255, 255, 0.9)"
-                : "rgba(0, 0, 0, 0.8)",
-            }}
+      <Typography
+        variant="body2"
+        align="center"
+        sx={{
+          mb: 2,
+          color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+        }}
+      >
+        {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      </Typography>
+      <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
           >
-            Agentes por direccion general - Planta y Contratos
-          </Typography>
-          <Chip
-            label="Dirección General"
-            size="small"
-            variant="outlined"
-            sx={{ borderColor: COLOR, color: COLOR }}
-          />
-        </Box>
-        <Typography
-          variant="body2"
-          align="center"
-          sx={{
-            mb: 2,
-            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
-          }}
-        >
-          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
-        </Typography>
-        <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={pageData}
-              layout="vertical"
-              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
-              barCategoryGap={10}
-            >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={
-                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
-                }
-              />
-              <XAxis
-                type="number"
-                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
-                allowDecimals={false}
-                tickFormatter={formatMiles}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                }}
-              />
-              <YAxis
-                type="category"
-                dataKey="direccionGeneral"
-                width={260}
-                tickLine={false}
-                interval={0}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                  fontSize: 12,
-                }}
-              />
-              <Tooltip
-                wrapperStyle={{ outline: "none" }}
-                content={({ active, payload }) => (
-                  <UnifiedTooltip
-                    active={active}
-                    payload={payload}
+            <CartesianGrid
+              {...gridProps}
+              horizontal={false}
+              strokeDasharray="0 0"
+            />
+            <XAxis
+              {...axisProps}
+              type="number"
+              domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+              allowDecimals={false}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisProps}
+              type="category"
+              dataKey="direccionGeneral"
+              width={260}
+              tickLine={false}
+              interval={0}
+            />
+            <Tooltip
+              {...tooltipProps}
+              content={({ active, payload }) => (
+                <UnifiedTooltip
+                  active={active}
+                  payload={payload}
+                  dark={isDarkMode}
+                  label={`Dirección General: ${
+                    payload?.[0]?.payload?.direccionGeneral ||
+                    "Sin especificar"
+                  }`}
+                >
+                  {payload?.length && (
+                    <>
+                      <div>
+                        Cantidad de agentes: {" "}
+                        {formatMiles(payload[0].payload.cantidad)}
+                      </div>
+                      <div>
+                        Porcentaje: {" "}
+                        {formatPct(
+                          (payload[0].payload.cantidad || 0) /
+                            (grandTotal || 1),
+                        )}
+                      </div>
+                    </>
+                  )}
+                </UnifiedTooltip>
+              )}
+            />
+            <Bar dataKey="cantidad" maxBarSize={22} fill={primary}>
+              <LabelList
+                dataKey="cantidad"
+                content={(p) => (
+                  <ValueLabel
+                    {...p}
+                    total={grandTotal}
                     dark={isDarkMode}
-                    label={`Dirección General: ${payload?.[0]?.payload?.direccionGeneral || "Sin especificar"}`}
-                  >
-                    {payload?.length && (
-                      <>
-                        <div>
-                          Cantidad de agentes:{" "}
-                          {formatMiles(payload[0].payload.cantidad)}
-                        </div>
-                        <div>
-                          Porcentaje:{" "}
-                          {formatPct(
-                            (payload[0].payload.cantidad || 0) /
-                              (grandTotal || 1),
-                          )}
-                        </div>
-                      </>
-                    )}
-                  </UnifiedTooltip>
+                  />
                 )}
               />
-              <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList
-                  dataKey="cantidad"
-                  content={(p) => <EndOutsideLabel {...p} />}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {chartData.length > PAGE && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages}
-            onPrev={() => setPage((p) => Math.max(0, p - 1))}
-            onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-          />
-        )}
-      </CardContent>
-    </Card>
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {chartData.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      )}
+    </DashboardCard>
   );
 };
 

--- a/frontend/src/components/AgentsByDivisionBarChart.jsx
+++ b/frontend/src/components/AgentsByDivisionBarChart.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
-import DeviceHubIcon from "@mui/icons-material/DeviceHub";
+import { Typography, Box, Chip } from "@mui/material";
 import {
   BarChart,
   Bar,
@@ -11,12 +10,23 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
-import { formatMiles, formatPct, UnifiedTooltip } from "./ui/chart-utils";
+import DashboardCard from "./ui/DashboardCard.jsx";
 import PaginationControls from "./ui/PaginationControls.jsx";
-
-const COLOR = "#84cc16";
+import {
+  formatMiles,
+  formatPct,
+  UnifiedTooltip,
+  rechartsCommon,
+  ValueLabel,
+} from "./ui/chart-utils";
+import icons from "./ui/icons.js";
+import { useTheme } from "../context/ThemeContext.jsx";
 
 const AgentsByDivisionBarChart = ({ data, isDarkMode }) => {
+  const { theme } = useTheme();
+  const primary = theme.palette.primary.main;
+  const { axisProps, gridProps, tooltipProps } = rechartsCommon(isDarkMode);
+
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
       division: (d.division ?? "").toString().trim() || "Sin especificar",
@@ -49,173 +59,111 @@ const AgentsByDivisionBarChart = ({ data, isDarkMode }) => {
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
   }, [pageData, grandTotal]);
 
-  const EndOutsideLabel = (props) => {
-    const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
-    const row = pageData?.[index] || {};
-    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
-    const color = isDarkMode ? "#ffffff" : "#0f172a";
-    return (
-      <text
-        x={x + width + 8}
-        y={y + (height || 0) / 2}
-        fontSize={12}
-        textAnchor="start"
-        dominantBaseline="central"
-        fill={color}
-        fontWeight="600"
-        pointerEvents="none"
-      >
-        {label}
-      </text>
-    );
-  };
-
   return (
-    <Card
-      sx={{
-        height: "100%",
-        background: isDarkMode
-          ? "rgba(45, 55, 72, 0.8)"
-          : "rgba(255, 255, 255, 0.9)",
-        backdropFilter: "blur(20px)",
-        border: isDarkMode
-          ? "1px solid rgba(255, 255, 255, 0.1)"
-          : "1px solid rgba(0, 0, 0, 0.08)",
-        borderLeft: `6px solid ${COLOR}`,
-        borderRadius: 3,
-        transition: "all 0.3s ease",
-        "&:hover": {
-          transform: "translateY(-4px)",
-          boxShadow: isDarkMode
-            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
-            : "0 12px 40px rgba(0, 0, 0, 0.15)",
-        },
-      }}
+    <DashboardCard
+      title="Agentes por División - Planta y Contratos"
+      icon={<icons.distribucion />}
+      isDarkMode={isDarkMode}
+      headerRight={
+        <Chip
+          label="División"
+          size="small"
+          variant="outlined"
+          sx={{ borderColor: primary, color: primary }}
+        />
+      }
     >
-      <CardContent sx={{ p: 3 }}>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 1.25,
-          }}
-        >
-          <DeviceHubIcon sx={{ color: COLOR }} />
-          <Typography
-            variant="h6"
-            align="center"
-            sx={{
-              fontWeight: 600,
-              color: isDarkMode
-                ? "rgba(255, 255, 255, 0.9)"
-                : "rgba(0, 0, 0, 0.8)",
-            }}
+      <Typography
+        variant="body2"
+        align="center"
+        sx={{
+          mb: 2,
+          color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+        }}
+      >
+        {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      </Typography>
+      <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
           >
-            Agentes por division - Planta y Contratos
-          </Typography>
-          <Chip
-            label="División"
-            size="small"
-            variant="outlined"
-            sx={{ borderColor: COLOR, color: COLOR }}
-          />
-        </Box>
-        <Typography
-          variant="body2"
-          align="center"
-          sx={{
-            mb: 2,
-            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
-          }}
-        >
-          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
-        </Typography>
-        <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={pageData}
-              layout="vertical"
-              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
-              barCategoryGap={10}
-            >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={
-                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
-                }
-              />
-              <XAxis
-                type="number"
-                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
-                allowDecimals={false}
-                tickFormatter={formatMiles}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                }}
-              />
-              <YAxis
-                type="category"
-                dataKey="division"
-                width={240}
-                tickLine={false}
-                interval={0}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                  fontSize: 12,
-                }}
-              />
-              <Tooltip
-                wrapperStyle={{ outline: "none" }}
-                content={({ active, payload }) => (
-                  <UnifiedTooltip
-                    active={active}
-                    payload={payload}
+            <CartesianGrid
+              {...gridProps}
+              horizontal={false}
+              strokeDasharray="0 0"
+            />
+            <XAxis
+              {...axisProps}
+              type="number"
+              domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+              allowDecimals={false}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisProps}
+              type="category"
+              dataKey="division"
+              width={240}
+              tickLine={false}
+              interval={0}
+            />
+            <Tooltip
+              {...tooltipProps}
+              content={({ active, payload }) => (
+                <UnifiedTooltip
+                  active={active}
+                  payload={payload}
+                  dark={isDarkMode}
+                  label={`División: ${
+                    payload?.[0]?.payload?.division || "Sin especificar"
+                  }`}
+                >
+                  {payload?.length && (
+                    <>
+                      <div>
+                        Cantidad de agentes: {" "}
+                        {formatMiles(payload[0].payload.cantidad)}
+                      </div>
+                      <div>
+                        Porcentaje: {" "}
+                        {formatPct(
+                          (payload[0].payload.cantidad || 0) /
+                            (grandTotal || 1),
+                        )}
+                      </div>
+                    </>
+                  )}
+                </UnifiedTooltip>
+              )}
+            />
+            <Bar dataKey="cantidad" maxBarSize={22} fill={primary}>
+              <LabelList
+                dataKey="cantidad"
+                content={(p) => (
+                  <ValueLabel
+                    {...p}
+                    total={grandTotal}
                     dark={isDarkMode}
-                    label={`División: ${payload?.[0]?.payload?.division || "Sin especificar"}`}
-                  >
-                    {payload?.length && (
-                      <>
-                        <div>
-                          Cantidad de agentes:{" "}
-                          {formatMiles(payload[0].payload.cantidad)}
-                        </div>
-                        <div>
-                          Porcentaje:{" "}
-                          {formatPct(
-                            (payload[0].payload.cantidad || 0) /
-                              (grandTotal || 1),
-                          )}
-                        </div>
-                      </>
-                    )}
-                  </UnifiedTooltip>
+                  />
                 )}
               />
-              <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList
-                  dataKey="cantidad"
-                  content={(p) => <EndOutsideLabel {...p} />}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {chartData.length > PAGE && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages}
-            onPrev={() => setPage((p) => Math.max(0, p - 1))}
-            onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-          />
-        )}
-      </CardContent>
-    </Card>
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {chartData.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      )}
+    </DashboardCard>
   );
 };
 

--- a/frontend/src/components/AgentsBySecretariaBarChart.jsx
+++ b/frontend/src/components/AgentsBySecretariaBarChart.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
-import BusinessIcon from "@mui/icons-material/Business";
+import { Typography, Box, Chip } from "@mui/material";
 import {
   BarChart,
   Bar,
@@ -11,12 +10,23 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
-import { formatMiles, formatPct, UnifiedTooltip } from "./ui/chart-utils";
+import DashboardCard from "./ui/DashboardCard.jsx";
 import PaginationControls from "./ui/PaginationControls.jsx";
-
-const COLOR = "#14b8a6";
+import {
+  formatMiles,
+  formatPct,
+  UnifiedTooltip,
+  rechartsCommon,
+  ValueLabel,
+} from "./ui/chart-utils";
+import icons from "./ui/icons.js";
+import { useTheme } from "../context/ThemeContext.jsx";
 
 const AgentsBySecretariaBarChart = ({ data, isDarkMode }) => {
+  const { theme } = useTheme();
+  const primary = theme.palette.primary.main;
+  const { axisProps, gridProps, tooltipProps } = rechartsCommon(isDarkMode);
+
   // Normalizar y ordenar datos por cantidad desc
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
@@ -52,177 +62,111 @@ const AgentsBySecretariaBarChart = ({ data, isDarkMode }) => {
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
   }, [pageData, grandTotal]);
 
-  // Etiqueta personalizada a la derecha: cantidad + porcentaje
-  const EndOutsideLabel = (props) => {
-    const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
-    const row = pageData?.[index] || {};
-    const cnt = Number(row.cantidad ?? 0);
-    const label = formatPct((cnt || 0) / (grandTotal || 1));
-    const xText = x + width + 8;
-    const yText = y + (height || 0) / 2;
-    const color = isDarkMode ? "#ffffff" : "#0f172a";
-    return (
-      <text
-        x={xText}
-        y={yText}
-        fontSize={12}
-        textAnchor="start"
-        dominantBaseline="central"
-        fill={color}
-        fontWeight="600"
-        pointerEvents="none"
-      >
-        {label}
-      </text>
-    );
-  };
-
   return (
-    <Card
-      sx={{
-        height: "100%",
-        background: isDarkMode
-          ? "rgba(45, 55, 72, 0.8)"
-          : "rgba(255, 255, 255, 0.9)",
-        backdropFilter: "blur(20px)",
-        border: isDarkMode
-          ? "1px solid rgba(255, 255, 255, 0.1)"
-          : "1px solid rgba(0, 0, 0, 0.08)",
-        borderLeft: `6px solid ${COLOR}`,
-        borderRadius: 3,
-        transition: "all 0.3s ease",
-        "&:hover": {
-          transform: "translateY(-4px)",
-          boxShadow: isDarkMode
-            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
-            : "0 12px 40px rgba(0, 0, 0, 0.15)",
-        },
-      }}
+    <DashboardCard
+      title="Agentes por Secretaría - Planta y Contratos"
+      icon={<icons.distribucion />}
+      isDarkMode={isDarkMode}
+      headerRight={
+        <Chip
+          label="Secretaría"
+          size="small"
+          variant="outlined"
+          sx={{ borderColor: primary, color: primary }}
+        />
+      }
     >
-      <CardContent sx={{ p: 3 }}>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 1.25,
-          }}
-        >
-          <BusinessIcon sx={{ color: COLOR }} />
-          <Typography
-            variant="h6"
-            align="center"
-            sx={{
-              fontWeight: 600,
-              color: isDarkMode
-                ? "rgba(255, 255, 255, 0.9)"
-                : "rgba(0, 0, 0, 0.8)",
-            }}
+      <Typography
+        variant="body2"
+        align="center"
+        sx={{
+          mb: 2,
+          color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+        }}
+      >
+        {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      </Typography>
+      <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
           >
-            Agentes por Secretaría - Planta y Contratos
-          </Typography>
-          <Chip
-            label="Secretaría"
-            size="small"
-            variant="outlined"
-            sx={{ borderColor: COLOR, color: COLOR }}
-          />
-        </Box>
-        <Typography
-          variant="body2"
-          align="center"
-          sx={{
-            mb: 2,
-            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
-          }}
-        >
-          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
-        </Typography>
-        <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={pageData}
-              layout="vertical"
-              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
-              barCategoryGap={10}
-            >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={
-                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
-                }
-              />
-              <XAxis
-                type="number"
-                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
-                allowDecimals={false}
-                tickFormatter={formatMiles}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                }}
-              />
-              <YAxis
-                type="category"
-                dataKey="secretaria"
-                width={240}
-                tickLine={false}
-                interval={0}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                  fontSize: 12,
-                }}
-              />
-              <Tooltip
-                wrapperStyle={{ outline: "none" }}
-                content={({ active, payload }) => (
-                  <UnifiedTooltip
-                    active={active}
-                    payload={payload}
+            <CartesianGrid
+              {...gridProps}
+              horizontal={false}
+              strokeDasharray="0 0"
+            />
+            <XAxis
+              {...axisProps}
+              type="number"
+              domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+              allowDecimals={false}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisProps}
+              type="category"
+              dataKey="secretaria"
+              width={240}
+              tickLine={false}
+              interval={0}
+            />
+            <Tooltip
+              {...tooltipProps}
+              content={({ active, payload }) => (
+                <UnifiedTooltip
+                  active={active}
+                  payload={payload}
+                  dark={isDarkMode}
+                  label={`Secretaría: ${
+                    payload?.[0]?.payload?.secretaria || "Sin especificar"
+                  }`}
+                >
+                  {payload?.length && (
+                    <>
+                      <div>
+                        Cantidad de agentes: {" "}
+                        {formatMiles(payload[0].payload.cantidad)}
+                      </div>
+                      <div>
+                        Porcentaje: {" "}
+                        {formatPct(
+                          (payload[0].payload.cantidad || 0) /
+                            (grandTotal || 1),
+                        )}
+                      </div>
+                    </>
+                  )}
+                </UnifiedTooltip>
+              )}
+            />
+            <Bar dataKey="cantidad" maxBarSize={22} fill={primary}>
+              <LabelList
+                dataKey="cantidad"
+                content={(props) => (
+                  <ValueLabel
+                    {...props}
+                    total={grandTotal}
                     dark={isDarkMode}
-                    label={`Secretaría: ${payload?.[0]?.payload?.secretaria || "Sin especificar"}`}
-                  >
-                    {payload?.length && (
-                      <>
-                        <div>
-                          Cantidad de agentes:{" "}
-                          {formatMiles(payload[0].payload.cantidad)}
-                        </div>
-                        <div>
-                          Porcentaje:{" "}
-                          {formatPct(
-                            (payload[0].payload.cantidad || 0) /
-                              (grandTotal || 1),
-                          )}
-                        </div>
-                      </>
-                    )}
-                  </UnifiedTooltip>
+                  />
                 )}
               />
-              <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList
-                  dataKey="cantidad"
-                  content={(props) => <EndOutsideLabel {...props} />}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {chartData.length > PAGE && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages}
-            onPrev={() => setPage((p) => Math.max(0, p - 1))}
-            onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-          />
-        )}
-      </CardContent>
-    </Card>
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {chartData.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      )}
+    </DashboardCard>
   );
 };
 

--- a/frontend/src/components/AgentsBySubsecretariaBarChart.jsx
+++ b/frontend/src/components/AgentsBySubsecretariaBarChart.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
-import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import { Typography, Box, Chip } from "@mui/material";
 import {
   BarChart,
   Bar,
@@ -11,12 +10,23 @@ import {
   ResponsiveContainer,
   LabelList,
 } from "recharts";
-import { formatMiles, formatPct, UnifiedTooltip } from "./ui/chart-utils";
+import DashboardCard from "./ui/DashboardCard.jsx";
 import PaginationControls from "./ui/PaginationControls.jsx";
-
-const COLOR = "#f59e0b";
+import {
+  formatMiles,
+  formatPct,
+  UnifiedTooltip,
+  rechartsCommon,
+  ValueLabel,
+} from "./ui/chart-utils";
+import icons from "./ui/icons.js";
+import { useTheme } from "../context/ThemeContext.jsx";
 
 const AgentsBySubsecretariaBarChart = ({ data, isDarkMode }) => {
+  const { theme } = useTheme();
+  const primary = theme.palette.primary.main;
+  const { axisProps, gridProps, tooltipProps } = rechartsCommon(isDarkMode);
+
   const chartData = useMemo(() => {
     const rows = (data || []).map((d) => ({
       subsecretaria:
@@ -50,173 +60,111 @@ const AgentsBySubsecretariaBarChart = ({ data, isDarkMode }) => {
     return Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, approxWidth));
   }, [pageData, grandTotal]);
 
-  const EndOutsideLabel = (props) => {
-    const { x = 0, y = 0, width = 0, height = 0, index = 0 } = props;
-    const row = pageData?.[index] || {};
-    const label = formatPct((row.cantidad || 0) / (grandTotal || 1));
-    const color = isDarkMode ? "#ffffff" : "#0f172a";
-    return (
-      <text
-        x={x + width + 8}
-        y={y + (height || 0) / 2}
-        fontSize={12}
-        textAnchor="start"
-        dominantBaseline="central"
-        fill={color}
-        fontWeight="600"
-        pointerEvents="none"
-      >
-        {label}
-      </text>
-    );
-  };
-
   return (
-    <Card
-      sx={{
-        height: "100%",
-        background: isDarkMode
-          ? "rgba(45, 55, 72, 0.8)"
-          : "rgba(255, 255, 255, 0.9)",
-        backdropFilter: "blur(20px)",
-        border: isDarkMode
-          ? "1px solid rgba(255, 255, 255, 0.1)"
-          : "1px solid rgba(0, 0, 0, 0.08)",
-        borderLeft: `6px solid ${COLOR}`,
-        borderRadius: 3,
-        transition: "all 0.3s ease",
-        "&:hover": {
-          transform: "translateY(-4px)",
-          boxShadow: isDarkMode
-            ? "0 12px 40px rgba(0, 0, 0, 0.4)"
-            : "0 12px 40px rgba(0, 0, 0, 0.15)",
-        },
-      }}
+    <DashboardCard
+      title="Agentes por Subsecretaría - Planta y Contratos"
+      icon={<icons.distribucion />}
+      isDarkMode={isDarkMode}
+      headerRight={
+        <Chip
+          label="Subsecretaría"
+          size="small"
+          variant="outlined"
+          sx={{ borderColor: primary, color: primary }}
+        />
+      }
     >
-      <CardContent sx={{ p: 3 }}>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 1.25,
-          }}
-        >
-          <AccountTreeIcon sx={{ color: COLOR }} />
-          <Typography
-            variant="h6"
-            align="center"
-            sx={{
-              fontWeight: 600,
-              color: isDarkMode
-                ? "rgba(255, 255, 255, 0.9)"
-                : "rgba(0, 0, 0, 0.8)",
-            }}
+      <Typography
+        variant="body2"
+        align="center"
+        sx={{
+          mb: 2,
+          color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+        }}
+      >
+        {chartData.length} categorías • {formatMiles(grandTotal)} agentes
+      </Typography>
+      <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={pageData}
+            layout="vertical"
+            margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
+            barCategoryGap={10}
           >
-            Agentes por Subsecretaría - Planta y Contratos
-          </Typography>
-          <Chip
-            label="Subsecretaría"
-            size="small"
-            variant="outlined"
-            sx={{ borderColor: COLOR, color: COLOR }}
-          />
-        </Box>
-        <Typography
-          variant="body2"
-          align="center"
-          sx={{
-            mb: 2,
-            color: isDarkMode ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
-          }}
-        >
-          {chartData.length} categorías • {formatMiles(grandTotal)} agentes
-        </Typography>
-        <Box sx={{ height: Math.max(320, pageData.length * 40) }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={pageData}
-              layout="vertical"
-              margin={{ top: 16, right: dynamicRight, bottom: 16, left: 260 }}
-              barCategoryGap={10}
-            >
-              <CartesianGrid
-                horizontal={false}
-                strokeDasharray="0 0"
-                stroke={
-                  isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"
-                }
-              />
-              <XAxis
-                type="number"
-                domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
-                allowDecimals={false}
-                tickFormatter={formatMiles}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                }}
-              />
-              <YAxis
-                type="category"
-                dataKey="subsecretaria"
-                width={240}
-                tickLine={false}
-                interval={0}
-                tick={{
-                  fill: isDarkMode
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(0,0,0,0.7)",
-                  fontSize: 12,
-                }}
-              />
-              <Tooltip
-                wrapperStyle={{ outline: "none" }}
-                content={({ active, payload }) => (
-                  <UnifiedTooltip
-                    active={active}
-                    payload={payload}
+            <CartesianGrid
+              {...gridProps}
+              horizontal={false}
+              strokeDasharray="0 0"
+            />
+            <XAxis
+              {...axisProps}
+              type="number"
+              domain={[0, (max) => Math.ceil((max || 0) * 1.2)]}
+              allowDecimals={false}
+              tickFormatter={formatMiles}
+            />
+            <YAxis
+              {...axisProps}
+              type="category"
+              dataKey="subsecretaria"
+              width={240}
+              tickLine={false}
+              interval={0}
+            />
+            <Tooltip
+              {...tooltipProps}
+              content={({ active, payload }) => (
+                <UnifiedTooltip
+                  active={active}
+                  payload={payload}
+                  dark={isDarkMode}
+                  label={`Subsecretaría: ${
+                    payload?.[0]?.payload?.subsecretaria || "Sin especificar"
+                  }`}
+                >
+                  {payload?.length && (
+                    <>
+                      <div>
+                        Cantidad de agentes: {" "}
+                        {formatMiles(payload[0].payload.cantidad)}
+                      </div>
+                      <div>
+                        Porcentaje: {" "}
+                        {formatPct(
+                          (payload[0].payload.cantidad || 0) /
+                            (grandTotal || 1),
+                        )}
+                      </div>
+                    </>
+                  )}
+                </UnifiedTooltip>
+              )}
+            />
+            <Bar dataKey="cantidad" maxBarSize={22} fill={primary}>
+              <LabelList
+                dataKey="cantidad"
+                content={(p) => (
+                  <ValueLabel
+                    {...p}
+                    total={grandTotal}
                     dark={isDarkMode}
-                    label={`Subsecretaría: ${payload?.[0]?.payload?.subsecretaria || "Sin especificar"}`}
-                  >
-                    {payload?.length && (
-                      <>
-                        <div>
-                          Cantidad de agentes:{" "}
-                          {formatMiles(payload[0].payload.cantidad)}
-                        </div>
-                        <div>
-                          Porcentaje:{" "}
-                          {formatPct(
-                            (payload[0].payload.cantidad || 0) /
-                              (grandTotal || 1),
-                          )}
-                        </div>
-                      </>
-                    )}
-                  </UnifiedTooltip>
+                  />
                 )}
               />
-              <Bar dataKey="cantidad" maxBarSize={22} fill={COLOR}>
-                <LabelList
-                  dataKey="cantidad"
-                  content={(p) => <EndOutsideLabel {...p} />}
-                />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-        {chartData.length > PAGE && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages}
-            onPrev={() => setPage((p) => Math.max(0, p - 1))}
-            onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-          />
-        )}
-      </CardContent>
-    </Card>
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+      {chartData.length > PAGE && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPrev={() => setPage((p) => Math.max(0, p - 1))}
+          onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+        />
+      )}
+    </DashboardCard>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace MUI cards with DashboardCard using `icons.distribucion`
- use `rechartsCommon` and theme primary color across agent bar charts
- add percentage labels and pagination controls

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1edc8450c83278ba20d2851f9bcb8